### PR TITLE
Fix #398 - OreDictionaryExportBus not working with craftable items

### DIFF
--- a/src/main/scala/extracells/part/PartOreDictExporter.java
+++ b/src/main/scala/extracells/part/PartOreDictExporter.java
@@ -86,7 +86,7 @@ public class PartOreDictExporter extends PartECBase implements IGridTickable {
 		IStorageGrid storage = getStorageGrid();
 		IAEItemStack stack = null;
 		for (IAEItemStack s : storage.getItemInventory().getStorageList()) {
-			if (checkItem(s.copy())) {
+			if (s.getStackSize() > 0 && checkItem(s.copy())) {  // skip craftable items not in storage
 				stack = s.copy();
 				break;
 			}


### PR DESCRIPTION
Fixes a problem where the OreDict Export Bus would not export some items if there is a crafting pattern for an item that matches the specified OreDict.