### PR TITLE
fix ec2 voiding some part of items when inserting in more than one slots

### DIFF
--- a/src/main/scala/extracells/tileentity/TileEntityFluidInterface.java
+++ b/src/main/scala/extracells/tileentity/TileEntityFluidInterface.java
@@ -587,9 +587,7 @@ public class TileEntityFluidInterface extends TileBase implements
 												.copy();
 										s.stackSize = max;
 										inv.setInventorySlotContents(i, s);
-										IAEStack c = this.export.get(0).copy();
-										c.setStackSize(outStack - max + current);
-										this.export.set(0, c);
+										this.export.get(0).setStackSize(outStack - max + current);
 										return;
 									}
 								}
@@ -626,9 +624,7 @@ public class TileEntityFluidInterface extends TileBase implements
 												.copy();
 										s.stackSize = max;
 										inv.setInventorySlotContents(i, s);
-										IAEStack c = this.export.get(0).copy();
-										c.setStackSize(outStack - max + current);
-										this.export.set(0, c);
+										this.export.get(0).setStackSize(outStack - max + current);
 										return;
 									}
 								}
@@ -652,9 +648,7 @@ public class TileEntityFluidInterface extends TileBase implements
 						} else {
 							FluidStack fl = fluid.getFluidStack().copy();
 							fl.amount = amount;
-							IAEStack c = this.export.get(0).copy();
-							c.setStackSize(fluid.getStackSize() - handler.fill(dir.getOpposite(), fl, true));
-							this.export.set(0, c);
+							this.export.get(0).setStackSize(fluid.getStackSize() - handler.fill(dir.getOpposite(), fl, true));
 							return;
 						}
 					}
@@ -714,7 +708,7 @@ public class TileEntityFluidInterface extends TileBase implements
 												new FluidStack(fluid,
 														(int) (amount + 0))),
 								Actionable.MODULATE, new MachineSource(this));
-				this.export.add(extractFluid);
+				this.export.add(extractFluid.copy());
 			}
 			for (IAEItemStack s : patter.getCondensedInputs()) {
 				if (s == null)
@@ -723,7 +717,7 @@ public class TileEntityFluidInterface extends TileBase implements
 					this.toExport = s.copy();
 					continue;
 				}
-				this.export.add(s);
+				this.export.add(s.copy());
 			}
 
 		}

--- a/src/main/scala/extracells/tileentity/TileEntityFluidInterface.java
+++ b/src/main/scala/extracells/tileentity/TileEntityFluidInterface.java
@@ -587,7 +587,9 @@ public class TileEntityFluidInterface extends TileBase implements
 												.copy();
 										s.stackSize = max;
 										inv.setInventorySlotContents(i, s);
-										this.export.get(0).setStackSize(outStack - max + current);
+										IAEStack c = this.export.get(0).copy();
+										c.setStackSize(outStack - max + current);
+										this.export.set(0, c);
 										return;
 									}
 								}
@@ -624,7 +626,9 @@ public class TileEntityFluidInterface extends TileBase implements
 												.copy();
 										s.stackSize = max;
 										inv.setInventorySlotContents(i, s);
-										this.export.get(0).setStackSize(outStack - max + current);
+										IAEStack c = this.export.get(0).copy();
+										c.setStackSize(outStack - max + current);
+										this.export.set(0, c);
 										return;
 									}
 								}
@@ -648,7 +652,9 @@ public class TileEntityFluidInterface extends TileBase implements
 						} else {
 							FluidStack fl = fluid.getFluidStack().copy();
 							fl.amount = amount;
-							this.export.get(0).setStackSize(fluid.getStackSize() - handler.fill(dir.getOpposite(), fl, true));
+							IAEStack c = this.export.get(0).copy();
+							c.setStackSize(fluid.getStackSize() - handler.fill(dir.getOpposite(), fl, true));
+							this.export.set(0, c);
 							return;
 						}
 					}


### PR DESCRIPTION
setStackSize affects recipe stack so it starts to export less items with each new stack in target inventory

e.g. 30 item recipe x 10 crafting requests (e.g. 10 lapotrons)

```
importing: 30 imported: 30
importing: 30 imported: 60
importing: 30 imported: 64 overflow 26
importing: 26 imported: 64 26
importing: 26 imported: 64 52
importing: 26 imported: 64 64 overflow 14
importing: 14 imported: 64 64 14
importing: 14 imported: 64 64 28
importing: 14 imported: 64 64 42
importing: 14 imported: 64 64 56
importing: 14 imported: 64 64 64 overflow 6
importing: 6 imported: 64 64 64 6
importing: 6 imported: 64 64 64 12
```


expected 300 items imported, actual 204 items.

next crafting requests insert only 6 items even when requesting 1 craft


broken after fixing dupe
may be related to https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/6324
but example world is broken and i cannot reproduce