### PR TITLE
remove the registration of the fluid pattern for every fluid

### DIFF
--- a/src/main/scala/extracells/item/ItemFluidPattern.java
+++ b/src/main/scala/extracells/item/ItemFluidPattern.java
@@ -2,9 +2,7 @@ package extracells.item;
 
 import extracells.registries.ItemEnum;
 import net.minecraft.client.renderer.texture.IIconRegister;
-import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.IIcon;
@@ -13,8 +11,6 @@ import net.minecraft.world.World;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
-
-import java.util.List;
 
 public class ItemFluidPattern extends ItemECBase {
 
@@ -62,18 +58,6 @@ public class ItemFluidPattern extends ItemECBase {
 	@Override
 	public int getSpriteNumber() {
 		return 1;
-	}
-
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	@Override
-	public void getSubItems(Item item, CreativeTabs creativeTab, List itemList) {
-        super.getSubItems(item, creativeTab, itemList);
-		for (Fluid fluid : FluidRegistry.getRegisteredFluidIDsByFluid().keySet()) {
-			ItemStack itemStack = new ItemStack(this, 1);
-			itemStack.setTagCompound(new NBTTagCompound());
-			itemStack.getTagCompound().setString("fluidID", fluid.getName());
-			itemList.add(itemStack);
-		}
 	}
 
 	@Override


### PR DESCRIPTION
This removes all the fluid patterns in NEI and the EC2 creative tab except the blank one. (when you check their recipe it shows the recipe of the blank one, and there was no use found by NEI for them)

Should get rid of 1151 fluid patterns, according to amount of them in NEI in the 2.1.0.0 version of  GT:NH