### PR TITLE
Buffed IO speeds of Fluid Interfaces and Buses, increased capacity of Fluid Interface.

### DIFF
--- a/src/main/scala/extracells/part/PartFluidIO.java
+++ b/src/main/scala/extracells/part/PartFluidIO.java
@@ -60,6 +60,7 @@ public abstract class PartFluidIO extends PartECBase implements IGridTickable,
 			return false;
 		}
 	};
+        private static final Integer MAX_IO = 1000;
 
 	@Override
 	public void getDrops( List<ItemStack> drops, boolean wrenched) {
@@ -135,13 +136,13 @@ public abstract class PartFluidIO extends PartECBase implements IGridTickable,
 		if (tag.hasKey("speed"))
 			oldList.add(tag.getInteger("speed") + "mB/t");
 		else
-			oldList.add("125mB/t");
+		    oldList.add(String.format("%d mB/t", this.MAX_IO));
 		return oldList;
 	}
 
 	@Override
 	public NBTTagCompound getWailaTag(NBTTagCompound tag) {
-		tag.setInteger("speed", 125 + this.speedState * 125);
+		tag.setInteger("speed", this.MAX_IO + this.speedState * this.MAX_IO);
 		return tag;
 	}
 
@@ -254,7 +255,7 @@ public abstract class PartFluidIO extends PartECBase implements IGridTickable,
 	public final TickRateModulation tickingRequest(IGridNode node,
 			int TicksSinceLastCall) {
 		if (canDoWork())
-			return doWork(125 + this.speedState * 125, TicksSinceLastCall) ? TickRateModulation.FASTER
+			return doWork(this.MAX_IO + this.speedState * this.MAX_IO, TicksSinceLastCall) ? TickRateModulation.FASTER
 					: TickRateModulation.SLOWER;
 		return TickRateModulation.SLOWER;
 	}

--- a/src/main/scala/extracells/part/PartFluidInterface.java
+++ b/src/main/scala/extracells/part/PartFluidInterface.java
@@ -75,6 +75,8 @@ public class PartFluidInterface extends PartECBase implements IFluidHandler,
 	private class FluidInterfaceInventory implements IInventory {
 
 		private ItemStack[] inv = new ItemStack[9];
+	        private static final Integer MAX_TANK = 32000;
+      	        private static final Integer MAX_IO   = 8000;
 
 		@Override
 		public void closeInventory() {}
@@ -207,7 +209,7 @@ public class PartFluidInterface extends PartECBase implements IFluidHandler,
 	private IAEItemStack toExport = null;
 
 	private final Item encodedPattern = AEApi.instance().definitions().items().encodedPattern().maybeItem().orNull();
-	private FluidTank tank = new FluidTank(10000) {
+	private FluidTank tank = new FluidTank(this.MAX_TANK) {
 		@Override
 		public FluidTank readFromNBT(NBTTagCompound nbt) {
 			if (!nbt.hasKey("Empty")) {
@@ -931,7 +933,7 @@ public class PartFluidInterface extends PartECBase implements IFluidHandler,
 		if (this.tank.getFluid() != null
 				&& FluidRegistry.getFluid(this.fluidFilter) != this.tank
 						.getFluid().getFluid()) {
-			FluidStack s = this.tank.drain(125, false);
+			FluidStack s = this.tank.drain(this.MAX_IO, false);
 			if (s != null) {
 				IAEFluidStack notAdded = storage.getFluidInventory()
 						.injectItems(

--- a/src/main/scala/extracells/tileentity/TileEntityFluidInterface.java
+++ b/src/main/scala/extracells/tileentity/TileEntityFluidInterface.java
@@ -196,13 +196,16 @@ public class TileEntityFluidInterface extends TileBase implements
 	private List<IAEItemStack> watcherList = new ArrayList<IAEItemStack>();
 
 	private boolean isFirstGetGridNode = true;
+	
+	private static final Integer MAX_SIZE = 32000;
+	private static final Integer MAX_DRAIN = 8000;
 
 	public TileEntityFluidInterface() {
 		super();
 		this.inventory = new FluidInterfaceInventory();
 		this.gridBlock = new ECFluidGridBlock(this);
 		for (int i = 0; i < this.tanks.length; i++) {
-			this.tanks[i] = new FluidTank(10000) {
+			this.tanks[i] = new FluidTank(this.MAX_SIZE) {
 				@Override
 				public FluidTank readFromNBT(NBTTagCompound nbt) {
 					if (!nbt.hasKey("Empty")) {
@@ -866,7 +869,7 @@ public class TileEntityFluidInterface extends TileBase implements
 			if (this.tanks[i].getFluid() != null
 					&& FluidRegistry.getFluid(this.fluidFilter[i]) != this.tanks[i]
 							.getFluid().getFluid()) {
-				FluidStack s = this.tanks[i].drain(125, false);
+				FluidStack s = this.tanks[i].drain(this.MAX_DRAIN, false);
 				if (s != null) {
 					IAEFluidStack notAdded = storage.getFluidInventory()
 							.injectItems(


### PR DESCRIPTION
Previously the base speed for both was 125 L/t, which is slower than an MV pump. Buses could get up to 625 L/t with the maximum number of acceleration cards, which is slightly better than an HV pump. This change makes the buses actually competitive compared to HV/EV pumps and makes interfaces actually somewhat viable for fluid outputting. 
Fluid Import/Output buses now max out at 5000 L/t
Fluid Interfaces max out at 8000 L/t and now have a capacity of 32000L per tank (the capacity of a ULV tank).

This makes an IO bus land somewhere between an HV and EV pump, and an interface nearly able to supply an IV pump.