### PR TITLE
A bunch of EC2 bugfixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,3 +17,6 @@ end_of_line = crlf
 
 [*.{dtd,json,mcmeta,md,sh,svg,xml,xsd,xsl,yaml,yml}]
 indent_size = 2
+
+[*.{java,scala}]
+indent_style = tab

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,13 +1,13 @@
 // Add your dependencies here
 
 dependencies {
-    compile('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-77-GTNH:dev')
+    compile('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-82-GTNH:dev')
 
-    compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.2.7-GTNH:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:NotEnoughItems:2.2.11-GTNH:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.3.16-GTNH:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:CodeChickenLib:1.1.5.3:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:waila:1.5.19:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:WirelessCraftingTerminal:1.8.8.3:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:WirelessCraftingTerminal:1.8.8.4:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:OpenComputers:1.7.5.23-GTNH:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.27:dev') {transitive=false}
 

--- a/src/main/scala/extracells/api/IFluidStorageCell.java
+++ b/src/main/scala/extracells/api/IFluidStorageCell.java
@@ -20,4 +20,8 @@ public interface IFluidStorageCell extends ICellWorkbenchItem {
 
 	public int getMaxTypes(ItemStack is);
 
+	public default double idleDrain(ItemStack is) {
+		return 0.0;
+	}
+
 }

--- a/src/main/scala/extracells/item/ItemStorageFluid.java
+++ b/src/main/scala/extracells/item/ItemStorageFluid.java
@@ -33,6 +33,8 @@ public class ItemStorageFluid extends ItemECBase implements IFluidStorageCell {
 
 	public static final int[] spaces = { 1024, 4096, 16348, 65536, 262144, 1048576, 4194304 };
 
+	public static final double[] idle_drains = {0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5};
+
 	private IIcon[] icons;
 
 	public ItemStorageFluid() {
@@ -44,7 +46,7 @@ public class ItemStorageFluid extends ItemECBase implements IFluidStorageCell {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void addInformation(ItemStack itemStack, EntityPlayer player,
-			List list, boolean par4) {
+							   List list, boolean par4) {
 		IMEInventoryHandler<IAEFluidStack> handler = AEApi.instance().registries().cell().getCellInventory(itemStack, null, StorageChannel.FLUIDS);
 		if (!(handler instanceof IHandlerFluidStorage)) {
 			return;
@@ -114,10 +116,16 @@ public class ItemStorageFluid extends ItemECBase implements IFluidStorageCell {
 		return 5;
 	}
 
+	@Override
+	public double idleDrain(ItemStack is) {
+		int variant = MathHelper.clamp_int(is.getItemDamage(), 0, idle_drains.length);
+		return idle_drains[variant];
+	}
+
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public void getSubItems(Item item, CreativeTabs creativeTab,
-			List listSubItems) {
+							List listSubItems) {
 		for (int i = 0; i < suffixes.length; ++i) {
 			listSubItems.add(new ItemStack(item, 1, i));
 		}
@@ -143,7 +151,7 @@ public class ItemStorageFluid extends ItemECBase implements IFluidStorageCell {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public ItemStack onItemRightClick(ItemStack itemStack, World world,
-			EntityPlayer entityPlayer) {
+									  EntityPlayer entityPlayer) {
 		if (!entityPlayer.isSneaking()) {
 			return itemStack;
 		}

--- a/src/main/scala/extracells/item/ItemStoragePhysical.java
+++ b/src/main/scala/extracells/item/ItemStoragePhysical.java
@@ -179,7 +179,9 @@ public class ItemStoragePhysical extends ItemECBase implements IStorageCell,
 
 	@Override
 	public double getIdleDrain() {
-		return 0;
+		// AE2 API needs fixing to provide an ItemStack here to allow type-dependent idle drain.
+		// 2.5 corresponds to 256k based on vanilla AE2 idle drain progression
+		return 2.5;
 	}
 
 	@SideOnly(Side.CLIENT)

--- a/src/main/scala/extracells/item/ItemStoragePhysical.java
+++ b/src/main/scala/extracells/item/ItemStoragePhysical.java
@@ -294,20 +294,22 @@ public class ItemStoragePhysical extends ItemECBase implements IStorageCell,
 			EntityPlayer entityPlayer) {
 		if (itemStack == null)
 			return itemStack;
-		if (itemStack.getItemDamage() == 4 && !world.isRemote && entityPlayer.isSneaking()) {
-			switch (itemStack.getTagCompound().getInteger("mode")) {
-			case 0:
-				itemStack.getTagCompound().setInteger("mode", 1);
-				entityPlayer.addChatMessage(new ChatComponentTranslation("extracells.tooltip.storage.container.1"));
-				break;
-			case 1:
-				itemStack.getTagCompound().setInteger("mode", 2);
-				entityPlayer.addChatMessage(new ChatComponentTranslation("extracells.tooltip.storage.container.2"));
-				break;
-			case 2:
-				itemStack.getTagCompound().setInteger("mode", 0);
-				entityPlayer.addChatMessage(new ChatComponentTranslation("extracells.tooltip.storage.container.0"));
-				break;
+		if (itemStack.getItemDamage() == 4 && entityPlayer.isSneaking()) {
+			if (!world.isRemote) {
+				switch (itemStack.getTagCompound().getInteger("mode")) {
+					case 0:
+						itemStack.getTagCompound().setInteger("mode", 1);
+						entityPlayer.addChatMessage(new ChatComponentTranslation("extracells.tooltip.storage.container.1"));
+						break;
+					case 1:
+						itemStack.getTagCompound().setInteger("mode", 2);
+						entityPlayer.addChatMessage(new ChatComponentTranslation("extracells.tooltip.storage.container.2"));
+						break;
+					case 2:
+						itemStack.getTagCompound().setInteger("mode", 0);
+						entityPlayer.addChatMessage(new ChatComponentTranslation("extracells.tooltip.storage.container.0"));
+						break;
+				}
 			}
 			return itemStack;
 		}

--- a/src/main/scala/extracells/item/ItemStoragePortableFluidCell.scala
+++ b/src/main/scala/extracells/item/ItemStoragePortableFluidCell.scala
@@ -21,7 +21,7 @@ import net.minecraftforge.fluids.{Fluid, FluidRegistry}
 
 object ItemStoragePortableFluidCell extends ItemECBase with IPortableFluidStorageCell with PowerItem {
 
-  override val MAX_POWER: Double = 20000
+  override val MAX_POWER: Double = 100000
   private[item] var icon: IIcon = null
   def THIS = this
   setMaxStackSize(1)
@@ -87,7 +87,8 @@ object ItemStoragePortableFluidCell extends ItemECBase with IPortableFluidStorag
   }
 
   def getMaxBytes(is: ItemStack): Int = {
-    return 512
+    // 8192 buckets when using only one fluid type
+    return 32768
   }
 
 

--- a/src/main/scala/extracells/part/PartFluidStorageMonitor.java
+++ b/src/main/scala/extracells/part/PartFluidStorageMonitor.java
@@ -15,6 +15,7 @@ import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEStack;
 import appeng.api.storage.data.IItemList;
 import appeng.api.util.AEColor;
+import appeng.api.util.INetworkToolAgent;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import extracells.render.TextureManager;
@@ -32,10 +33,7 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.util.ChatComponentTranslation;
-import net.minecraft.util.IIcon;
-import net.minecraft.util.StatCollector;
-import net.minecraft.util.Vec3;
+import net.minecraft.util.*;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
@@ -48,7 +46,7 @@ import org.lwjgl.opengl.GL12;
 import java.io.IOException;
 import java.util.List;
 
-public class PartFluidStorageMonitor extends PartECBase implements IStackWatcherHost {
+public class PartFluidStorageMonitor extends PartECBase implements IStackWatcherHost, INetworkToolAgent {
 
 	Fluid fluid = null;
 	long amount = 0L;
@@ -519,5 +517,11 @@ public class PartFluidStorageMonitor extends PartECBase implements IStackWatcher
 			data.writeInt(this.fluid.getID());
 		data.writeBoolean(this.locked);
 
+	}
+
+	@Override
+	public boolean showNetworkInfo( final MovingObjectPosition where )
+	{
+		return false;
 	}
 }

--- a/src/main/scala/extracells/part/PartFluidStorageMonitor.java
+++ b/src/main/scala/extracells/part/PartFluidStorageMonitor.java
@@ -205,6 +205,7 @@ public class PartFluidStorageMonitor extends PartECBase implements IStackWatcher
 			this.fluid = FluidUtil.getFluidFromContainer(s).getFluid();
 			if (this.watcher != null)
 				this.watcher.add(FluidUtil.createAEFluidStack(this.fluid));
+			updateFluidAmount();
 			IPartHost host = getHost();
 			if (host != null)
 				host.markForUpdate();
@@ -213,9 +214,7 @@ public class PartFluidStorageMonitor extends PartECBase implements IStackWatcher
 		return false;
 	}
 
-	@Override
-	public void onStackChange(IItemList arg0, IAEStack arg1, IAEStack arg2,
-			BaseActionSource arg3, StorageChannel arg4) {
+	protected void updateFluidAmount() {
 		if (this.fluid != null) {
 			IGridNode n = getGridNode();
 			if (n == null)
@@ -243,7 +242,12 @@ public class PartFluidStorageMonitor extends PartECBase implements IStackWatcher
 			if (host != null)
 				host.markForUpdate();
 		}
+	}
 
+	@Override
+	public void onStackChange(IItemList arg0, IAEStack arg1, IAEStack arg2,
+			BaseActionSource arg3, StorageChannel arg4) {
+		updateFluidAmount();
 	}
 
 	@Override

--- a/src/main/scala/extracells/util/FluidCellHandler.java
+++ b/src/main/scala/extracells/util/FluidCellHandler.java
@@ -19,7 +19,11 @@ public class FluidCellHandler implements ICellHandler {
 
 	@Override
 	public double cellIdleDrain(ItemStack is, IMEInventory handler) {
-		return 0;
+		if (!(is.getItem() instanceof IFluidStorageCell)) {
+			return 0.0;
+		}
+		final IFluidStorageCell cell = (IFluidStorageCell) is.getItem();
+		return cell.idleDrain(is);
 	}
 
 	@Override

--- a/src/main/scala/extracells/util/FluidUtil.java
+++ b/src/main/scala/extracells/util/FluidUtil.java
@@ -47,8 +47,8 @@ public class FluidUtil {
 			int amountDrained = content != null
 					&& content.getFluid() == fluid.getFluid() ? content.amount
 					: 0;
-			return new MutablePair<Integer, ItemStack>(amountDrained, itemStack
-					.getItem().getContainerItem(itemStack));
+			return new MutablePair<Integer, ItemStack>(amountDrained,
+				FluidContainerRegistry.drainFluidContainer(itemStack));
 		}
 
 		return null;

--- a/src/main/scala/extracells/util/inventory/ECPrivateInventory.java
+++ b/src/main/scala/extracells/util/inventory/ECPrivateInventory.java
@@ -105,6 +105,7 @@ public class ECPrivateInventory implements IInventory {
 		added.stackSize = slot.stackSize + amount > stackLimit ? stackLimit
 				: amount;
 		slot.stackSize += added.stackSize;
+		markDirty();
 		return added;
 	}
 


### PR DESCRIPTION
From <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/6099> this fixes:

- EC2 higher item cells don't consume AE (256k+) -> they now all consume what a 256k cell should consume, because the api doesn't give an itemstack to make it different for different cell types
- EC2 fluid cells don't consume AE -> they now consume AE same as regular AE cells, dependent on type as the above API limitation doesn't matter here as EC2 registers its own cell handler
- The ME Portable Fluid Storage only contains 128 buckets, why would you ever use it? -> increased capacity to ~iridium cell level and energy 5x so you can use it for more operations before recharging
- Fluid storage and conversion monitors locking with network tool doesn't work (but does with certus/NQ wrench -> fixed
- Fluid storage and conversion monitors won't display fluid amount -> they were not updating when right clicked with a cell, fixed
- When placing filled cells into a fluid terminal with a bucket in the output, it just voids the cells. Probably does this with anything different between I/O since it expects only buckets? -> ec2 was using the wrong method to detect the drained fluid container, fixed
 - When changing modes of the ME Block Container when it hasn't been locked to an item, it gives you a free Advanced Storage Housing, probably because the command conflicts with the one for separating components and housings. You can see a component for a millisecond before it goes back to being the BC. You can repeat this. - fixed
