### PR TITLE
Fix EC2 handling of IC2 Cells and show fluid amounts in fluid terminal

### DIFF
--- a/src/main/scala/extracells/container/ContainerFluidStorage.java
+++ b/src/main/scala/extracells/container/ContainerFluidStorage.java
@@ -163,7 +163,7 @@ public class ContainerFluidStorage extends Container implements
 		if (FluidUtil.isEmpty(container)) {
 			if (this.selectedFluid == null)
 				return;
-			int capacity = FluidUtil.getCapacity(container);
+			int capacity = FluidUtil.getCapacity(container, this.selectedFluid);
 			//Tries to simulate the extraction of fluid from storage.
 			IAEFluidStack result = this.monitor.extractItems(FluidUtil.createAEFluidStack(this.selectedFluid, capacity), Actionable.SIMULATE, new PlayerSource(this.player, null));
 

--- a/src/main/scala/extracells/gui/GuiFluidStorage.java
+++ b/src/main/scala/extracells/gui/GuiFluidStorage.java
@@ -10,6 +10,7 @@ import extracells.gui.widget.fluid.IFluidSelectorContainer;
 import extracells.gui.widget.fluid.IFluidSelectorGui;
 import extracells.gui.widget.fluid.WidgetFluidSelector;
 import extracells.network.packet.part.PacketFluidStorage;
+import extracells.util.FluidUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiTextField;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -66,20 +67,7 @@ public class GuiFluidStorage extends GuiContainer implements IFluidSelectorGui {
 		drawWidgets(mouseX, mouseY);
 		if (this.currentFluid != null) {
 			long currentFluidAmount = this.currentFluid.getStackSize();
-			String amountToText = Long.toString(currentFluidAmount) + "mB";
-			if (Extracells.shortenedBuckets()) {
-				if (currentFluidAmount > 1000000000L)
-					amountToText = Long
-							.toString(currentFluidAmount / 1000000000L)
-							+ "MegaB";
-				else if (currentFluidAmount > 1000000L)
-					amountToText = Long.toString(currentFluidAmount / 1000000L)
-							+ "KiloB";
-				else if (currentFluidAmount > 9999L) {
-					amountToText = Long.toString(currentFluidAmount / 1000L)
-							+ "B";
-				}
-			}
+			String amountToText = FluidUtil.formatFluidAmount(currentFluidAmount, true);
 
 			this.fontRendererObj.drawString(
 					StatCollector.translateToLocal("extracells.tooltip.amount")

--- a/src/main/scala/extracells/gui/GuiFluidTerminal.java
+++ b/src/main/scala/extracells/gui/GuiFluidTerminal.java
@@ -11,6 +11,7 @@ import extracells.gui.widget.fluid.IFluidSelectorGui;
 import extracells.gui.widget.fluid.WidgetFluidSelector;
 import extracells.network.packet.part.PacketFluidTerminal;
 import extracells.part.PartFluidTerminal;
+import extracells.util.FluidUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiTextField;
 import net.minecraft.client.gui.inventory.GuiContainer;
@@ -62,17 +63,7 @@ public class GuiFluidTerminal extends GuiContainer implements IFluidSelectorGui 
 		drawWidgets(mouseX, mouseY);
 		if (this.currentFluid != null) {
 			long currentFluidAmount = this.currentFluid.getStackSize();
-			String amountToText = Long.toString(currentFluidAmount) + "mB";
-			if (Extracells.shortenedBuckets()) {
-				if (currentFluidAmount > 1000000000L)
-					amountToText = Long
-							.toString(currentFluidAmount / 1000000000L) + "MegaB";
-				else if (currentFluidAmount > 1000000L)
-					amountToText = Long.toString(currentFluidAmount / 1000000L) + "KiloB";
-				else if (currentFluidAmount > 9999L) {
-					amountToText = Long.toString(currentFluidAmount / 1000L) + "B";
-				}
-			}
+			String amountToText = FluidUtil.formatFluidAmount(currentFluidAmount, true);
 
 			this.fontRendererObj.drawString(
 					StatCollector.translateToLocal("extracells.tooltip.amount") + ": " + amountToText, 45, 91, 0x000000);

--- a/src/main/scala/extracells/gui/widget/fluid/WidgetFluidSelector.java
+++ b/src/main/scala/extracells/gui/widget/fluid/WidgetFluidSelector.java
@@ -2,7 +2,9 @@ package extracells.gui.widget.fluid;
 
 import appeng.api.storage.data.IAEFluidStack;
 import extracells.Extracells;
+import extracells.util.FluidUtil;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
@@ -51,17 +53,7 @@ public class WidgetFluidSelector extends AbstractFluidWidget {
 						mouseX, mouseY))
 			return false;
 
-		String amountToText = Long.toString(this.amount) + "mB";
-		if (Extracells.shortenedBuckets()) {
-			if (this.amount > 1000000000L)
-				amountToText = Long.toString(this.amount / 1000000000L)
-						+ "MegaB";
-			else if (this.amount > 1000000L)
-				amountToText = Long.toString(this.amount / 1000000L) + "KiloB";
-			else if (this.amount > 9999L) {
-				amountToText = Long.toString(this.amount / 1000L) + "B";
-			}
-		}
+		String amountToText = FluidUtil.formatFluidAmount(this.amount, true);
 
 		List<String> description = new ArrayList<String>();
 		description.add(this.fluid.getLocalizedName(new FluidStack(this.fluid, 0)));
@@ -74,6 +66,7 @@ public class WidgetFluidSelector extends AbstractFluidWidget {
 
 	@Override
 	public void drawWidget(int posX, int posY) {
+		FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
 		Minecraft.getMinecraft().renderEngine
 				.bindTexture(TextureMap.locationBlocksTexture);
 		GL11.glDisable(GL11.GL_LIGHTING);
@@ -90,6 +83,25 @@ public class WidgetFluidSelector extends AbstractFluidWidget {
 					this.fluid.getIcon(), this.height - 2, this.width - 2);
 		}
 		GL11.glColor3f(1F, 1F, 1F);
+
+		final float scaleFactor = 0.5f;
+		final float inverseScaleFactor = 1.0f / scaleFactor;
+		final float offset = -1.0f;
+		final String stackSize = FluidUtil.formatFluidAmount(this.amount);
+
+		GL11.glDisable( GL11.GL_BLEND );
+		GL11.glDisable( GL11.GL_DEPTH_TEST );
+		GL11.glPushMatrix();
+		GL11.glScaled( scaleFactor, scaleFactor, scaleFactor );
+
+		final int X = (int) ( ( (float) posX + offset + 16.0f - fontRenderer.getStringWidth( stackSize ) * scaleFactor ) * inverseScaleFactor );
+		final int Y = (int) ( ( (float) posY + offset + 16.0f - 7.0f * scaleFactor ) * inverseScaleFactor );
+		fontRenderer.drawStringWithShadow( stackSize, X, Y, 16777215 );
+
+		GL11.glPopMatrix();
+		GL11.glEnable( GL11.GL_BLEND );
+		GL11.glEnable( GL11.GL_DEPTH_TEST );
+
 		if (this.fluid == currentFluid)
 			drawHollowRectWithCorners(posX, posY, this.height, this.width,
 					this.color, this.borderThickness);

--- a/src/main/scala/extracells/integration/opencomputers/DriverFluidExportBus.java
+++ b/src/main/scala/extracells/integration/opencomputers/DriverFluidExportBus.java
@@ -1,5 +1,6 @@
 package extracells.integration.opencomputers;
 
+import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartHost;
 import extracells.part.PartFluidExport;
@@ -40,7 +41,7 @@ public class DriverFluidExportBus implements SidedBlock{
 			return null;
 		return new Environment((IPartHost) tile);
 	}
-	
+
 	private static PartFluidExport getExportBus(World world, int x, int y, int z, ForgeDirection dir){
 		TileEntity tile = world.getTileEntity(x, y, z);
 		if (tile == null || (!(tile instanceof IPartHost)))
@@ -60,12 +61,12 @@ public class DriverFluidExportBus implements SidedBlock{
 			return null;
 		}
 	}
-	
+
 	public class Environment extends ManagedEnvironment implements NamedBlock{
-		
+
 		protected final TileEntity tile;
 		protected final IPartHost host;
-		
+
 		Environment(IPartHost host){
 			tile = (TileEntity) host;
 			this.host = host;
@@ -91,9 +92,9 @@ public class DriverFluidExportBus implements SidedBlock{
 			}catch(Throwable e){
 				return new Object[]{null, "Invalid slot"};
 			}
-			
+
 		}
-		
+
 		@Callback(doc = "function(side:number[, slot:number][, database:address, entry:number]):boolean -- Configure the fluid export bus pointing in the specified direction to export fluid stacks matching the specified descriptor.")
 		public Object[] setFluidExportConfiguration(Context context, Arguments args){
 			ForgeDirection dir = ForgeDirection.getOrientation(args.checkInteger(0));
@@ -150,7 +151,7 @@ public class DriverFluidExportBus implements SidedBlock{
 				return new Object[]{false, "invalid slot"};
 			}
 		}
-		
+
 		@Callback(doc = "function(side:number, amount:number):boolean -- Make the fluid export bus facing the specified direction perform a single export operation.")
 		public Object[] exportFluid(Context context, Arguments args){
 			ForgeDirection dir = ForgeDirection.getOrientation(args.checkInteger(0));
@@ -162,7 +163,7 @@ public class DriverFluidExportBus implements SidedBlock{
 			if (part.getFacingTank() == null)
 				return new Object[]{false, "no tank"};
 			int amount = Math.min(args.optInteger(1, 625), 125 + part.getSpeedState() * 125);
-			boolean didSomething = part.doWork(amount, 1);
+			boolean didSomething = part.doWork(amount, 1) == TickRateModulation.FASTER;
 			if (didSomething)
 				context.pause(0.25);
 			return new Object[]{didSomething};
@@ -177,7 +178,7 @@ public class DriverFluidExportBus implements SidedBlock{
 		public int priority() {
 			return 2;
 		}
-		
+
 	}
 	static class Provider implements EnvironmentProvider {
 		@Override

--- a/src/main/scala/extracells/integration/opencomputers/DriverGasExportBus.java
+++ b/src/main/scala/extracells/integration/opencomputers/DriverGasExportBus.java
@@ -1,5 +1,6 @@
 package extracells.integration.opencomputers;
 
+import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartHost;
 import extracells.part.PartGasExport;
@@ -160,7 +161,7 @@ public class DriverGasExportBus implements SidedBlock{
             if (part.getFacingGasTank() == null)
                 return new Object[]{false, "no tank"};
             int amount = Math.min(args.optInteger(1, 625), 125 + part.getSpeedState() * 125);
-            boolean didSomething = part.doWork(amount, 1);
+            boolean didSomething = part.doWork(amount, 1) == TickRateModulation.FASTER;
             if (didSomething)
                 context.pause(0.25);
             return new Object[]{didSomething};

--- a/src/main/scala/extracells/inventory/HandlerPartStorageFluid.java
+++ b/src/main/scala/extracells/inventory/HandlerPartStorageFluid.java
@@ -26,6 +26,9 @@ import net.minecraftforge.fluids.IFluidHandler;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Handler for fluid storage buses
+ */
 public class HandlerPartStorageFluid implements IMEInventoryHandler<IAEFluidStack>, IMEMonitorHandlerReceiver<IAEFluidStack> {
 
 	protected PartFluidStorage node;
@@ -45,7 +48,7 @@ public class HandlerPartStorageFluid implements IMEInventoryHandler<IAEFluidStac
 	public boolean canAccept(IAEFluidStack input) {
 		if (!this.node.isActive())
 			return false;
-		else if (this.tank == null && this.externalSystem == null && this.externalHandler == null || !(this.access == AccessRestriction.WRITE || this.access == AccessRestriction.READ_WRITE) || input == null)
+		else if (this.tank == null && this.externalSystem == null && this.externalHandler == null || !this.access.hasPermission(AccessRestriction.WRITE) || input == null)
 			return false;
 		else if (this.externalSystem != null) {
 			IStorageMonitorable monitor = this.externalSystem.getMonitorable(

--- a/src/main/scala/extracells/part/PartFluidExport.java
+++ b/src/main/scala/extracells/part/PartFluidExport.java
@@ -3,6 +3,7 @@ package extracells.part;
 import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.config.SecurityPermissions;
+import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartRenderHelper;
@@ -33,11 +34,13 @@ public class PartFluidExport extends PartFluidIO {
 	}
 
 	@Override
-	public boolean doWork(int rate, int TicksSinceLastCall) {
+	public TickRateModulation doWork(int rate, int TicksSinceLastCall) {
+		if (!isActive())
+			return TickRateModulation.IDLE;
 		IFluidHandler facingTank = getFacingTank();
-		if (facingTank == null || !isActive())
-			return false;
-		List<Fluid> filter = new ArrayList<Fluid>();
+		if (facingTank == null)
+			return TickRateModulation.IDLE;
+		List<Fluid> filter = new ArrayList<>();
 		filter.add(this.filterFluids[4]);
 
 		if (this.filterSize >= 1) {
@@ -69,12 +72,12 @@ public class PartFluidExport extends PartFluidIO {
 					stack = this.extractFluid(stack, Actionable.MODULATE);
 					if (stack != null && stack.getStackSize() > 0) {
 						facingTank.fill(this.getSide().getOpposite(), stack.getFluidStack(), true);
-						return true;
+						return TickRateModulation.FASTER;
 					}
 				}
 			}
 		}
-		return false;
+		return TickRateModulation.SLOWER;
 	}
 
 	@Override

--- a/src/main/scala/extracells/part/PartFluidIO.java
+++ b/src/main/scala/extracells/part/PartFluidIO.java
@@ -97,12 +97,12 @@ public abstract class PartFluidIO extends PartECBase implements IGridTickable,
 		}
 		return false;
 	}
-	
+
 	public byte getSpeedState(){
 		return this.speedState;
 	}
 
-	public abstract boolean doWork(int rate, int TicksSinceLastCall);
+	public abstract TickRateModulation doWork(int rate, int TicksSinceLastCall);
 
 	@Override
 	public abstract void getBoxes(IPartCollisionHelper bch);
@@ -253,10 +253,8 @@ public abstract class PartFluidIO extends PartECBase implements IGridTickable,
 	@Override
 	public final TickRateModulation tickingRequest(IGridNode node,
 			int TicksSinceLastCall) {
-		if (canDoWork())
-			return doWork(125 + this.speedState * 125, TicksSinceLastCall) ? TickRateModulation.FASTER
-					: TickRateModulation.SLOWER;
-		return TickRateModulation.SLOWER;
+		return canDoWork() ? doWork(125 + this.speedState * 125, TicksSinceLastCall)
+			: TickRateModulation.IDLE;
 	}
 
 	@Override

--- a/src/main/scala/extracells/part/PartFluidImport.java
+++ b/src/main/scala/extracells/part/PartFluidImport.java
@@ -4,6 +4,7 @@ import appeng.api.AEApi;
 import appeng.api.config.Actionable;
 import appeng.api.config.RedstoneMode;
 import appeng.api.config.SecurityPermissions;
+import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartRenderHelper;
@@ -45,9 +46,9 @@ public class PartFluidImport extends PartFluidIO implements IFluidHandler {
 	}
 
 	@Override
-	public boolean doWork(int rate, int TicksSinceLastCall) {
-		if (getFacingTank() == null || !isActive())
-			return false;
+	public TickRateModulation doWork(int rate, int TicksSinceLastCall) {
+		if (!isActive() || getFacingTank() == null)
+			return TickRateModulation.IDLE;
 		boolean empty = true;
 
 		List<Fluid> filter = new ArrayList<Fluid>();
@@ -74,11 +75,13 @@ public class PartFluidImport extends PartFluidIO implements IFluidHandler {
 				empty = false;
 
 				if (fillToNetwork(fluid, rate * TicksSinceLastCall)) {
-					return true;
+					return TickRateModulation.FASTER;
 				}
 			}
 		}
-		return empty && fillToNetwork(null, rate * TicksSinceLastCall);
+		return (empty && fillToNetwork(null, rate * TicksSinceLastCall))
+			? TickRateModulation.FASTER
+			: TickRateModulation.SLOWER;
 	}
 
 	@Override

--- a/src/main/scala/extracells/part/PartFluidLevelEmitter.java
+++ b/src/main/scala/extracells/part/PartFluidLevelEmitter.java
@@ -125,11 +125,15 @@ public class PartFluidLevelEmitter extends PartECBase implements
 	@Override
 	public void onStackChange(IItemList o, IAEStack fullStack,
 			IAEStack diffStack, BaseActionSource src, StorageChannel chan) {
+		long previousAmount = this.currentAmount;
 		if (chan == StorageChannel.FLUIDS && diffStack != null
 				&& ((IAEFluidStack) diffStack).getFluid() == this.fluid) {
 			this.currentAmount = fullStack != null ? fullStack.getStackSize()
 					: 0;
-
+			if (Long.compare(currentAmount, wantedAmount) == Long.compare(previousAmount, wantedAmount)) {
+				// Don't send updates when amount has changed, but not its relation to wantedAmount
+				return;
+			}
 			IGridNode node = getGridNode();
 			if (node != null) {
 				setActive(node.isActive());

--- a/src/main/scala/extracells/part/PartFluidTerminal.java
+++ b/src/main/scala/extracells/part/PartFluidTerminal.java
@@ -114,7 +114,7 @@ public class PartFluidTerminal extends PartECBase implements IGridTickable,
 		if (FluidUtil.isEmpty(container)) {
 			if (this.currentFluid == null)
 				return;
-			int capacity = FluidUtil.getCapacity(container);
+			int capacity = FluidUtil.getCapacity(container, this.currentFluid);
 			IAEFluidStack result = monitor.extractItems(FluidUtil.createAEFluidStack(this.currentFluid, capacity), Actionable.SIMULATE, this.machineSource);
 			int proposedAmount = result == null ? 0 : (int) Math.min(capacity, result.getStackSize());
 			if(proposedAmount == 0)

--- a/src/main/scala/extracells/part/PartGasExport.scala
+++ b/src/main/scala/extracells/part/PartGasExport.scala
@@ -16,11 +16,11 @@ class PartGasExport extends PartFluidExport{
   private val isMekanismEnabled = Integration.Mods.MEKANISMGAS.isEnabled
 
 
-  override def doWork(rate: Int, tickSinceLastCall: Int): Boolean ={
+  override def doWork(rate: Int, tickSinceLastCall: Int): TickRateModulation ={
     if (isMekanismEnabled)
       work(rate, tickSinceLastCall)
     else
-      false
+      TickRateModulation.IDLE
   }
 
 

--- a/src/main/scala/extracells/part/PartGasExport.scala
+++ b/src/main/scala/extracells/part/PartGasExport.scala
@@ -1,9 +1,9 @@
 package extracells.part
 
 import java.util
-
 import appeng.api.AEApi
 import appeng.api.config.Actionable
+import appeng.api.networking.ticking.TickRateModulation
 import appeng.api.storage.data.IAEFluidStack
 import cpw.mods.fml.common.Optional
 import extracells.integration.Integration
@@ -25,9 +25,9 @@ class PartGasExport extends PartFluidExport{
 
 
   @Optional.Method(modid = "MekanismAPI|gas")
-  protected  def work(rate: Int, ticksSinceLastCall: Int): Boolean ={
+  protected  def work(rate: Int, ticksSinceLastCall: Int): TickRateModulation ={
     val facingTank: IGasHandler = getFacingGasTank
-    if (facingTank == null || !isActive) return false
+    if (!isActive || facingTank == null) return TickRateModulation.IDLE
     val filter  = new util.ArrayList[Fluid]
     filter.add(this.filterFluids(4))
 
@@ -69,13 +69,13 @@ class PartGasExport extends PartFluidExport{
             val filled: Int = facingTank.receiveGas(getSide.getOpposite, gasStack, true)
             if (filled > 0) {
               extractGasFluid(AEApi.instance.storage.createFluidStack(new FluidStack(fluid, filled)), Actionable.MODULATE)
-              return true
+              return TickRateModulation.FASTER
             }
           }
         }
       }
     }
-    return false
+    return TickRateModulation.SLOWER
   }
 
 

--- a/src/main/scala/extracells/tileentity/TileEntityFluidFiller.java
+++ b/src/main/scala/extracells/tileentity/TileEntityFluidFiller.java
@@ -211,7 +211,7 @@ public class TileEntityFluidFiller extends TileBase implements IActionHost,
 			Fluid fluid = fluidStack.getFluid();
 			if (fluid == null)
 				continue;
-			int maxCapacity = FluidUtil.getCapacity(this.containerItem);
+			int maxCapacity = FluidUtil.getCapacity(this.containerItem, fluid);
 			if (maxCapacity == 0)
 				continue;
 			MutablePair<Integer, ItemStack> filled = FluidUtil.fillStack(
@@ -246,7 +246,7 @@ public class TileEntityFluidFiller extends TileBase implements IActionHost,
 						new FluidStack(
 								fluid.getFluid(),
 								FluidUtil.getCapacity(patternDetails
-										.getCondensedInputs()[0].getItemStack())));
+										.getCondensedInputs()[0].getItemStack(), fluid.getFluid())));
 		IAEFluidStack extracted = storage.getFluidInventory()
 				.extractItems(fluidStack.copy(), Actionable.SIMULATE,
 						new MachineSource(this));

--- a/src/main/scala/extracells/util/FluidUtil.java
+++ b/src/main/scala/extracells/util/FluidUtil.java
@@ -2,6 +2,7 @@ package extracells.util;
 
 import appeng.api.AEApi;
 import appeng.api.storage.data.IAEFluidStack;
+import extracells.Extracells;
 import extracells.item.ItemFluidPattern;
 import extracells.registries.ItemEnum;
 import net.minecraft.item.Item;
@@ -151,5 +152,24 @@ public class FluidUtil {
 		return item instanceof IFluidContainerItem
 				|| item == ItemEnum.FLUIDPATTERN.getItem()
 				|| FluidContainerRegistry.isContainer(itemStack);
+	}
+
+	public static String formatFluidAmount(long millibuckets, boolean forceLongForm) {
+		if (!forceLongForm) {
+			if (millibuckets >= 1_000_000_000_000L)
+				return String.format("%.1fG",millibuckets / 1_000_000_000_000.0);
+			else if (millibuckets >= 1_000_000_000L)
+				return String.format("%.1fM",millibuckets / 1_000_000_000.0);
+			else if (millibuckets >= 1_000_000L)
+				return String.format("%.1fk", millibuckets / 1_000_000.0);
+			else if (millibuckets >= 1_000L) {
+				return String.format("%.1f", millibuckets / 1_000.0);
+			}
+		}
+		return String.format("%,d%s", millibuckets, forceLongForm ? " mB" : "m");
+	}
+
+	public static String formatFluidAmount(long millibuckets) {
+		return formatFluidAmount(millibuckets, false);
 	}
 }

--- a/src/main/scala/extracells/util/FluidUtil.java
+++ b/src/main/scala/extracells/util/FluidUtil.java
@@ -86,7 +86,7 @@ public class FluidUtil {
 		return null;
 	}
 
-	public static int getCapacity(ItemStack itemStack) {
+	public static int getCapacity(ItemStack itemStack, Fluid fluid) {
 		if (itemStack == null)
 			return 0;
 		Item item = itemStack.getItem();
@@ -95,7 +95,7 @@ public class FluidUtil {
 		} else if (FluidContainerRegistry.isEmptyContainer(itemStack)) {
 			for (FluidContainerRegistry.FluidContainerData data : FluidContainerRegistry
 					.getRegisteredFluidContainerData()) {
-				if (data != null && data.emptyContainer.isItemEqual(itemStack)) {
+				if (data != null && data.emptyContainer.isItemEqual(itemStack) && data.fluid.getFluidID() == fluid.getID()) {
 					FluidStack interior = data.fluid;
 					return interior != null ? interior.amount : 0;
 				}


### PR DESCRIPTION
 - Fixed detecting capacity for cells, now it takes the fluid into account so the 144mB cells should work properly and reduce chance for any dupes/voids to occur
 - Made the buses use IDLE modulation when they can't operate to save tick time, like vanilla AE2 buses do
 - Fluid terminal tweaks: always show precise amount in tooltips, show short amount in the GUI for each fluid like so (copied from AE2 item renderer):
![Fluid terminal showing fluid amounts in each slot](https://i.ibb.co/mJ9xpXc/gtnh-fluid-terminal-tweaks.png)

I couldn't find any other obvious places that could cause dupes, or any egregious lag sources, so hopefully this improves the usability of EC2 fluid handling. It'd be great if someone could test this on a savefile that uses ec2