### PR TITLE
Fix displaying large fluid quantities in the fluid terminal

### DIFF
--- a/src/main/scala/extracells/network/packet/part/PacketFluidTerminal.java
+++ b/src/main/scala/extracells/network/packet/part/PacketFluidTerminal.java
@@ -141,9 +141,8 @@ public class PacketFluidTerminal extends AbstractPacket {
 		switch (this.mode) {
 		case 0:
 			for (IAEFluidStack stack : this.fluidStackList) {
-				FluidStack fluidStack = stack.getFluidStack();
-				writeFluid(fluidStack.getFluid(), out);
-				out.writeLong(fluidStack.amount);
+				writeFluid(stack.getFluid(), out);
+				out.writeLong(stack.getStackSize());
 			}
 			break;
 		case 1:


### PR DESCRIPTION
Fixes <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/7699>

`getFluidStack()` was not necessary and it truncates the real amount to a 32-bit int (2147483647)