### PR TITLE
Resilient AE operations: get rid of duplication/voiding possibilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1644612407
+//version: 1650343995
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -6,12 +6,11 @@ Also, you may replace this file at any time if there is an update available.
 Please check https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/build.gradle for updates.
 */
 
-import org.gradle.internal.logging.text.StyledTextOutput
-import org.gradle.internal.logging.text.StyledTextOutputFactory
-import org.gradle.internal.logging.text.StyledTextOutput.Style
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.internal.logging.text.StyledTextOutput.Style
+import org.gradle.internal.logging.text.StyledTextOutputFactory
 
 import java.util.concurrent.TimeUnit
 
@@ -104,6 +103,7 @@ checkPropertyExists("usesShadowedDependencies")
 checkPropertyExists("developmentEnvironmentUserName")
 
 boolean noPublishedSources = project.findProperty("noPublishedSources") ? project.noPublishedSources.toBoolean() : false
+boolean usesMixinDebug = project.findProperty('usesMixinDebug') ?: project.usesMixins.toBoolean()
 
 String javaSourceDir = "src/main/java/"
 String scalaSourceDir = "src/main/scala/"
@@ -175,7 +175,7 @@ configurations.all {
 try {
     'git config core.fileMode false'.execute()
 }
-catch (Exception e) {
+catch (Exception ignored) {
     out.style(Style.Failure).println("git isn't installed at all")
 }
 
@@ -185,7 +185,7 @@ String versionOverride = System.getenv("VERSION") ?: null
 try {
     identifiedVersion = versionOverride == null ? gitVersion() : versionOverride
 }
-catch (Exception e) {
+catch (Exception ignored) {
     out.style(Style.Failure).text(
         'This mod must be version controlled by Git AND the repository must provide at least one tag,\n' +
         'or the VERSION override must be set! ').style(Style.SuccessHeader).text('(Do NOT download from GitHub using the ZIP option, instead\n' +
@@ -199,7 +199,7 @@ ext {
     modVersion = identifiedVersion
 }
 
-if( identifiedVersion.equals(versionOverride) ) {
+if(identifiedVersion == versionOverride) {
     out.style(Style.Failure).text('Override version to ').style(Style.Identifier).text(modVersion).style(Style.Failure).println('!\7')
 }
 
@@ -214,13 +214,17 @@ else {
 def arguments = []
 def jvmArguments = []
 
-if(usesMixins.toBoolean()) {
+if (usesMixins.toBoolean()) {
     arguments += [
-            "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
+        "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
     ]
-    jvmArguments += [
-            "-Dmixin.debug.countInjections=true", "-Dmixin.debug.verbose=true", "-Dmixin.debug.export=true"
-    ]
+    if (usesMixinDebug.toBoolean()) {
+        jvmArguments += [
+            "-Dmixin.debug.countInjections=true",
+            "-Dmixin.debug.verbose=true",
+            "-Dmixin.debug.export=true"
+        ]
+    }
 }
 
 minecraft {
@@ -312,18 +316,23 @@ def refMap = "${tasks.compileJava.temporaryDir}" + File.separator + mixingConfig
 def mixinSrg = "${tasks.reobf.temporaryDir}" + File.separator + "mixins.srg"
 
 task generateAssets {
-    if(usesMixins.toBoolean()) {
-        getFile("/src/main/resources/mixins." + modId + ".json").text = """{
+    if (usesMixins.toBoolean()) {
+        def mixinConfigFile = getFile("/src/main/resources/mixins." + modId + ".json");
+        if (!mixinConfigFile.exists()) {
+            mixinConfigFile.text = """{
   "required": true,
   "minVersion": "0.7.11",
   "package": "${modGroup}.${mixinsPackage}",
   "plugin": "${modGroup}.${mixinPlugin}",
   "refmap": "${mixingConfigRefMap}",
   "target": "@env(DEFAULT)",
-  "compatibilityLevel": "JAVA_8"
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [],
+  "client": [],
+  "server": []
 }
-
 """
+        }
     }
 }
 
@@ -439,7 +448,7 @@ processResources {
 
 def getManifestAttributes() {
     def manifestAttributes = [:]
-    if(containsMixinsAndOrCoreModOnly.toBoolean() == false && (usesMixins.toBoolean() || coreModClass)) {
+    if(!containsMixinsAndOrCoreModOnly.toBoolean() && (usesMixins.toBoolean() || coreModClass)) {
         manifestAttributes += ["FMLCorePluginContainsFMLMod": true]
     }
 
@@ -455,14 +464,14 @@ def getManifestAttributes() {
         manifestAttributes += [
                 "TweakClass" : "org.spongepowered.asm.launch.MixinTweaker",
                 "MixinConfigs" : "mixins." + modId + ".json",
-                "ForceLoadAsMod" : containsMixinsAndOrCoreModOnly.toBoolean() == false
+                "ForceLoadAsMod" : !containsMixinsAndOrCoreModOnly.toBoolean()
         ]
     }
     return manifestAttributes
 }
 
 task sourcesJar(type: Jar) {
-    from (sourceSets.main.allJava)
+    from (sourceSets.main.allSource)
     from (file("$projectDir/LICENSE"))
     getArchiveClassifier().set('sources')
 }
@@ -517,7 +526,7 @@ task devJar(type: Jar) {
 }
 
 task apiJar(type: Jar) {
-    from (sourceSets.main.allJava) {
+    from (sourceSets.main.allSource) {
         include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/") + '/**'
     }
 
@@ -548,6 +557,9 @@ tasks.withType(GenerateModuleMetadata) {
     enabled = false
 }
 
+// workaround variable hiding in pom processing
+def projectConfigs = project.configurations
+
 publishing {
     publications {
         maven(MavenPublication) {
@@ -556,7 +568,7 @@ publishing {
                 artifact source: shadowJar, classifier: ""
             }
             if(!noPublishedSources) {
-                artifact source: sourcesJar, classifier: "src"
+                artifact source: sourcesJar, classifier: "sources"
             }
             artifact source: usesShadowedDependencies.toBoolean() ? shadowDevJar : devJar, classifier: "dev"
             if (apiPackage) {
@@ -568,16 +580,20 @@ publishing {
             // Using the identified version, not project.version as it has the prepended 1.7.10
             version = System.getenv("RELEASE_VERSION") ?: identifiedVersion
 
-            // remove extra garbage from who knows where
+            // remove extra garbage from minecraft and minecraftDeps configuration
             pom.withXml {
-                def badPomGroup = ['net.minecraft', 'com.google.code.findbugs', 'org.ow2.asm', 'com.typesafe.akka', 'com.typesafe', 'org.scala-lang',
-                                   'org.scala-lang.plugins', 'net.sf.jopt-simple', 'lzma', 'com.mojang', 'org.apache.commons', 'org.apache.httpcomponents',
-                                   'commons-logging', 'java3d', 'net.sf.trove4j', 'com.ibm.icu', 'com.paulscode', 'io.netty', 'com.google.guava',
-                                   'commons-io', 'commons-codec', 'net.java.jinput', 'net.java.jutils', 'com.google.code.gson', 'org.apache.logging.log4j',
-                                   'org.lwjgl.lwjgl', 'tv.twitch', 'org.jetbrains.kotlin', '']
+                def badArtifacts = [:].withDefault {[] as Set<String>}
+                for (configuration in [projectConfigs.minecraft, projectConfigs.minecraftDeps]) {
+                    for (dependency in configuration.allDependencies) {
+                        badArtifacts[dependency.group == null ? "" : dependency.group] += dependency.name
+                    }
+                }
+                // example for specifying extra stuff to ignore
+                // badArtifacts["org.example.group"] += "artifactName"
+
                 Node pomNode = asNode()
                 pomNode.dependencies.'*'.findAll() {
-                    badPomGroup.contains(it.groupId.text())
+                    badArtifacts[it.groupId.text()].contains(it.artifactId.text())
                 }.each() {
                     it.parent().remove(it)
                 }
@@ -721,7 +737,7 @@ def deobf(String sourceURL, String fileName) {
 // Helper methods
 
 def checkPropertyExists(String propertyName) {
-    if (project.hasProperty(propertyName) == false) {
+    if (!project.hasProperty(propertyName)) {
         throw new GradleException("This project requires a property \"" + propertyName + "\"! Please add it your \"gradle.properties\". You can find all properties and their description here: https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/gradle.properties")
     }
 }

--- a/src/main/scala/extracells/inventory/HandlerPartStorageFluid.java
+++ b/src/main/scala/extracells/inventory/HandlerPartStorageFluid.java
@@ -79,7 +79,7 @@ public class HandlerPartStorageFluid implements IMEInventoryHandler<IAEFluidStac
 	@Override
 	public IAEFluidStack extractItems(IAEFluidStack request, Actionable mode, BaseActionSource src) {
 		if (!this.node.isActive()
-				|| !(this.access == AccessRestriction.READ || this.access == AccessRestriction.READ_WRITE))
+				|| !this.access.hasPermission(AccessRestriction.READ))
 			return null;
 		if (this.externalSystem != null && request != null) {
 			IStorageMonitorable monitor = this.externalSystem.getMonitorable(
@@ -92,13 +92,13 @@ public class HandlerPartStorageFluid implements IMEInventoryHandler<IAEFluidStac
 				return null;
 			return fluidInventory.extractItems(request, mode, src);
 
-		}else if(externalHandler != null && request != null){
+		} else if(externalHandler != null && request != null) {
 			IMEInventory<IAEFluidStack> inventory = externalHandler.getInventory(this.tile, this.node.getSide().getOpposite(), StorageChannel.FLUIDS, new MachineSource(this.node));
 			if(inventory == null)
 				return null;
 			return inventory.extractItems(request, mode, new MachineSource(this.node));
 		}
-		if (this.tank == null || request == null || this.access == AccessRestriction.WRITE || this.access == AccessRestriction.NO_ACCESS)
+		if (this.tank == null || request == null)
 			return null;
 		FluidStack toDrain = request.getFluidStack();
 		if (!this.tank.canDrain(this.node.getSide().getOpposite(), toDrain.getFluid()))

--- a/src/main/scala/extracells/part/PartFluidConversionMonitor.java
+++ b/src/main/scala/extracells/part/PartFluidConversionMonitor.java
@@ -67,6 +67,7 @@ public class PartFluidConversionMonitor extends PartFluidStorageMonitor {
 			ItemStack newHeldItem = heldItem.copy();
 			newHeldItem.stackSize--;
 			player.inventory.setInventorySlotContents(player.inventory.currentItem, newHeldItem.stackSize <= 0 ? null : newHeldItem);
+			return true;
 		}
 		return false;
 	}

--- a/src/main/scala/extracells/part/PartFluidConversionMonitor.java
+++ b/src/main/scala/extracells/part/PartFluidConversionMonitor.java
@@ -20,7 +20,6 @@ import net.minecraft.util.IIcon;
 import net.minecraft.util.Vec3;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fluids.IFluidContainerItem;
 import org.apache.commons.lang3.tuple.MutablePair;
 
 public class PartFluidConversionMonitor extends PartFluidStorageMonitor {
@@ -33,90 +32,41 @@ public class PartFluidConversionMonitor extends PartFluidStorageMonitor {
 			return true;
 		if (player.worldObj.isRemote)
 			return true;
-		ItemStack s = player.getCurrentEquippedItem();
+		ItemStack heldItem = player.getCurrentEquippedItem();
 		IMEMonitor<IAEFluidStack> mon = getFluidStorage();
-		if (this.locked && s != null && mon != null) {
-			ItemStack s2 = s.copy();
-			s2.stackSize = 1;
-			if (FluidUtil.isFilled(s2)) {
-				FluidStack f = FluidUtil.getFluidFromContainer(s2);
-				if (f == null)
+		if (this.locked && heldItem != null && mon != null) {
+			ItemStack container = heldItem.copy();
+			container.stackSize = 1;
+			MachineSource src = new MachineSource(this);
+			ItemStack result = null;
+			if (FluidUtil.isFilled(container)) {
+				FluidStack f = FluidUtil.getFluidFromContainer(container);
+				if (f == null) {
 					return true;
-				IAEFluidStack fl = FluidUtil.createAEFluidStack(f);
-				IAEFluidStack not = mon.injectItems(fl.copy(),
-						Actionable.SIMULATE, new MachineSource(this));
-				if (mon.canAccept(fl)
-						&& (not == null || not.getStackSize() == 0L)) {
-					MutablePair<Integer, ItemStack> empty1 = FluidUtil.drainStack(s2, f);
-					int amount = empty1.getLeft();
-					if (amount > 0) {
-						f.amount = amount;
-						fl.setStackSize(amount);
-						not = mon.injectItems(fl.copy(), Actionable.SIMULATE, new MachineSource(this));
-						if (mon.canAccept(fl) && (not == null || not.getStackSize() == 0L)) {
-							mon.injectItems(fl, Actionable.MODULATE, new MachineSource(this));
-							ItemStack empty = empty1.right;
-							if (empty != null) {
-								TileEntity tile = this.getHost().getTile();
-								ForgeDirection side = this.getSide();
-								this.dropItems(tile.getWorldObj(), tile.xCoord + side.offsetX, tile.yCoord + side.offsetY, tile.zCoord + side.offsetZ, empty);
-							}
-							ItemStack s3 = s.copy();
-							s3.stackSize--;
-							if (s3.stackSize <= 0)
-								player.inventory.setInventorySlotContents(player.inventory.currentItem, null);
-							else
-								player.inventory.setInventorySlotContents(player.inventory.currentItem, s3);
-						}
-					}
 				}
-				return true;
-			} else if (FluidUtil.isEmpty(s2)) {
+				ItemStack simulation = FluidUtil.drainItemIntoAe(container, mon, Actionable.SIMULATE, src);
+				if (simulation == null) {
+					return true;
+				}
+				result = FluidUtil.drainItemIntoAe(container, mon, Actionable.MODULATE, src);
+			} else if (FluidUtil.isEmpty(container)) {
 				if (this.fluid == null)
 					return true;
-				IAEFluidStack extract;
-				if (s2.getItem() instanceof IFluidContainerItem) {
-					extract = mon.extractItems(FluidUtil.createAEFluidStack(
-							this.fluid, ((IFluidContainerItem) s2.getItem())
-									.getCapacity(s2)), Actionable.SIMULATE,
-							new MachineSource(this));
-				} else
-					extract = mon.extractItems(
-							FluidUtil.createAEFluidStack(this.fluid),
-							Actionable.SIMULATE, new MachineSource(this));
-				if (extract != null) {
-					if (extract.getStackSize() <= 0)
-						return true;
-					extract = mon.extractItems(extract, Actionable.MODULATE, new MachineSource(this));
-					if (extract == null || extract.getStackSize() <= 0)
-						return true;
-
-					MutablePair<Integer, ItemStack> empty1 = FluidUtil
-							.fillStack(s2, extract.getFluidStack());
-					if (empty1.left == 0) {
-						mon.injectItems(extract, Actionable.MODULATE, new MachineSource(this));
-						return true;
-					}
-					ItemStack empty = empty1.right;
-					if (empty != null) {
-						dropItems(getHost().getTile().getWorldObj(), getHost()
-								.getTile().xCoord + getSide().offsetX,
-								getHost().getTile().yCoord + getSide().offsetY,
-								getHost().getTile().zCoord + getSide().offsetZ,
-								empty);
-					}
-					ItemStack s3 = s.copy();
-					s3.stackSize = s3.stackSize - 1;
-					if (s3.stackSize == 0) {
-						player.inventory.setInventorySlotContents(
-								player.inventory.currentItem, null);
-					} else {
-						player.inventory.setInventorySlotContents(
-								player.inventory.currentItem, s3);
-					}
+				MutablePair<ItemStack, FluidStack> simulation = FluidUtil.fillItemFromAe(container, new FluidStack(this.fluid, Integer.MAX_VALUE), mon, Actionable.SIMULATE, src);
+				if (simulation == null || simulation.getLeft() == null) {
+					return true;
 				}
+				result = FluidUtil.fillItemFromAe(container, new FluidStack(this.fluid, Integer.MAX_VALUE), mon, Actionable.MODULATE, src).getLeft();
+			}
+			if (result == null) {
 				return true;
 			}
+			TileEntity tile = this.getHost().getTile();
+			ForgeDirection side = this.getSide();
+			this.dropItems(tile.getWorldObj(), tile.xCoord + side.offsetX, tile.yCoord + side.offsetY, tile.zCoord + side.offsetZ, result);
+			ItemStack newHeldItem = heldItem.copy();
+			newHeldItem.stackSize--;
+			player.inventory.setInventorySlotContents(player.inventory.currentItem, newHeldItem.stackSize <= 0 ? null : newHeldItem);
 		}
 		return false;
 	}

--- a/src/main/scala/extracells/part/PartFluidExport.java
+++ b/src/main/scala/extracells/part/PartFluidExport.java
@@ -78,7 +78,7 @@ public class PartFluidExport extends PartFluidIO {
 							// try to return to AE
 							int toReturn = filled - actuallyFilled;
 							IAEFluidStack returned = injectFluid(AEApi.instance().storage().createFluidStack(new FluidStack(fluid, toReturn)), Actionable.MODULATE);
-							if (returned.getStackSize() != toReturn) {
+							if (returned != null) {
 								FMLLog.severe("[ExtraCells2] Export bus at %d:%d,%d,%d voided %d mL of %s",
 									tile.getWorldObj().provider.dimensionId,
 									tile.xCoord,

--- a/src/main/scala/extracells/part/PartFluidExport.java
+++ b/src/main/scala/extracells/part/PartFluidExport.java
@@ -74,9 +74,9 @@ public class PartFluidExport extends PartFluidIO {
 					stack = this.extractFluid(stack, Actionable.MODULATE);
 					if (stack != null && stack.getStackSize() > 0) {
 						int actuallyFilled = facingTank.fill(this.getSide().getOpposite(), stack.getFluidStack(), true);
-						if (actuallyFilled < filled) {
+						if (actuallyFilled < stack.getStackSize()) {
 							// try to return to AE
-							int toReturn = filled - actuallyFilled;
+							int toReturn = (int)stack.getStackSize() - actuallyFilled;
 							IAEFluidStack returned = injectFluid(AEApi.instance().storage().createFluidStack(new FluidStack(fluid, toReturn)), Actionable.MODULATE);
 							if (returned != null) {
 								FMLLog.severe("[ExtraCells2] Export bus at %d:%d,%d,%d voided %d mL of %s",

--- a/src/main/scala/extracells/part/PartFluidExport.java
+++ b/src/main/scala/extracells/part/PartFluidExport.java
@@ -9,6 +9,7 @@ import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartRenderHelper;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.util.AEColor;
+import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import extracells.render.TextureManager;
@@ -16,6 +17,7 @@ import extracells.util.PermissionUtil;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.Vec3;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -35,7 +37,7 @@ public class PartFluidExport extends PartFluidIO {
 
 	@Override
 	public TickRateModulation doWork(int rate, int TicksSinceLastCall) {
-		if (!isActive())
+		if (!isActive() || tile == null)
 			return TickRateModulation.IDLE;
 		IFluidHandler facingTank = getFacingTank();
 		if (facingTank == null)
@@ -71,7 +73,21 @@ public class PartFluidExport extends PartFluidIO {
 					stack.setStackSize(filled);
 					stack = this.extractFluid(stack, Actionable.MODULATE);
 					if (stack != null && stack.getStackSize() > 0) {
-						facingTank.fill(this.getSide().getOpposite(), stack.getFluidStack(), true);
+						int actuallyFilled = facingTank.fill(this.getSide().getOpposite(), stack.getFluidStack(), true);
+						if (actuallyFilled < filled) {
+							// try to return to AE
+							int toReturn = filled - actuallyFilled;
+							IAEFluidStack returned = injectFluid(AEApi.instance().storage().createFluidStack(new FluidStack(fluid, toReturn)), Actionable.MODULATE);
+							if (returned.getStackSize() != toReturn) {
+								FMLLog.severe("[ExtraCells2] Export bus at %d:%d,%d,%d voided %d mL of %s",
+									tile.getWorldObj().provider.dimensionId,
+									tile.xCoord,
+									tile.yCoord,
+									tile.zCoord,
+									toReturn - returned.getStackSize(),
+									fluid.getName());
+							}
+						}
 						return TickRateModulation.FASTER;
 					}
 				}

--- a/src/main/scala/extracells/part/PartFluidIO.java
+++ b/src/main/scala/extracells/part/PartFluidIO.java
@@ -123,7 +123,7 @@ public abstract class PartFluidIO extends PartECBase implements IGridTickable,
 
 	@Override
 	public final TickingRequest getTickingRequest(IGridNode node) {
-		return new TickingRequest(1, 20, false, false);
+		return new TickingRequest(5, 60, false, false);
 	}
 
 	public ECPrivateInventory getUpgradeInventory() {

--- a/src/main/scala/extracells/part/PartFluidInterface.java
+++ b/src/main/scala/extracells/part/PartFluidInterface.java
@@ -928,7 +928,7 @@ public class PartFluidInterface extends PartECBase implements IFluidHandler,
 								AEApi.instance().storage()
 										.createFluidStack(s),
 								Actionable.SIMULATE, new MachineSource(this));
-				int toAdd = s.amount;
+				int toAdd = s.amount - (notAdded != null ? (int)notAdded.getStackSize() : 0);
 				IAEFluidStack actuallyNotInjected = storage.getFluidInventory().injectItems(
 					AEApi.instance()
 						.storage()
@@ -971,6 +971,9 @@ public class PartFluidInterface extends PartECBase implements IFluidHandler,
 			extracted = storage.getFluidInventory().extractItems(
 				request,
 				Actionable.MODULATE, new MachineSource(this));
+			if (extracted == null || extracted.getStackSize() <= 0) {
+				return TickRateModulation.SLOWER;
+			}
 			accepted = this.tank.fill(extracted.getFluidStack(), true);
 			if (extracted.getStackSize() != accepted) {
 				// This should never happen, but log it in case it does

--- a/src/main/scala/extracells/part/PartFluidInterface.java
+++ b/src/main/scala/extracells/part/PartFluidInterface.java
@@ -20,12 +20,12 @@ import appeng.api.networking.ticking.TickingRequest;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartRenderHelper;
-import appeng.api.parts.PartItemStack;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.IStorageMonitorable;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
 import appeng.api.storage.data.IAEStack;
+import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.common.network.ByteBufUtils;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -38,9 +38,9 @@ import extracells.crafting.CraftingPattern2;
 import extracells.gui.GuiFluidInterface;
 import extracells.network.packet.other.IFluidSlotPartOrBlock;
 import extracells.registries.ItemEnum;
-import extracells.registries.PartEnum;
 import extracells.render.TextureManager;
 import extracells.util.EmptyMeItemMonitor;
+import extracells.util.FluidUtil;
 import extracells.util.ItemUtils;
 import extracells.util.PermissionUtil;
 import io.netty.buffer.ByteBuf;
@@ -209,21 +209,10 @@ public class PartFluidInterface extends PartECBase implements IFluidHandler,
 	private IAEItemStack toExport = null;
 
 	private final Item encodedPattern = AEApi.instance().definitions().items().encodedPattern().maybeItem().orNull();
-	private FluidTank tank = new FluidTank(10000) {
-		@Override
-		public FluidTank readFromNBT(NBTTagCompound nbt) {
-			if (!nbt.hasKey("Empty")) {
-				FluidStack fluid = FluidStack.loadFluidStackFromNBT(nbt);
-				setFluid(fluid);
-			} else {
-				setFluid(null);
-			}
-			return this;
-		}
-	};
+	private FluidTank tank = new FluidTank(10000);
 	private int fluidFilter = -1;
 	public boolean doNextUpdate = false;
-	private boolean needBreake = false;
+	private boolean needBreak = false;
 
 	private int tickCount = 0;
 
@@ -304,17 +293,9 @@ public class PartFluidInterface extends PartECBase implements IFluidHandler,
 		IStorageGrid storage = grid.getCache(IStorageGrid.class);
 		if (storage == null)
 			return 0;
-		IAEFluidStack notRemoved;
-		FluidStack copy = resource.copy();
-		if (doFill) {
-			notRemoved = storage.getFluidInventory().injectItems(
-					AEApi.instance().storage().createFluidStack(resource),
-					Actionable.MODULATE, new MachineSource(this));
-		} else {
-			notRemoved = storage.getFluidInventory().injectItems(
-					AEApi.instance().storage().createFluidStack(resource),
-					Actionable.SIMULATE, new MachineSource(this));
-		}
+		IAEFluidStack notRemoved = storage.getFluidInventory().injectItems(
+			AEApi.instance().storage().createFluidStack(resource),
+			doFill ? Actionable.MODULATE : Actionable.SIMULATE, new MachineSource(this));
 		if (notRemoved == null)
 			return resource.amount;
 		return (int) (resource.amount - notRemoved.getStackSize());
@@ -648,8 +629,10 @@ public class PartFluidInterface extends PartECBase implements IFluidHandler,
 					if (amount == 0)
 						return;
 					if (amount == fluid.getStackSize()) {
-						handler.fill(dir.getOpposite(), fluid.getFluidStack()
-								.copy(), true);
+						amount = handler.fill(dir.getOpposite(), fluid.getFluidStack()
+							.copy(), true);
+					}
+					if (amount == fluid.getStackSize()) {
 						this.removeFromExport.add(stack0);
 					} else {
 						IAEFluidStack f = fluid.copy();
@@ -700,7 +683,7 @@ public class PartFluidInterface extends PartECBase implements IFluidHandler,
 										.storage()
 										.createFluidStack(
 												new FluidStack(fluid,
-														(int) (amount + 0))),
+														amount.intValue())),
 								Actionable.SIMULATE, new MachineSource(this));
 				if (extractFluid == null
 						|| extractFluid.getStackSize() != amount) {
@@ -715,7 +698,7 @@ public class PartFluidInterface extends PartECBase implements IFluidHandler,
 										.storage()
 										.createFluidStack(
 												new FluidStack(fluid,
-														(int) (amount + 0))),
+														amount.intValue())),
 								Actionable.MODULATE, new MachineSource(this));
 				this.export.add(extractFluid);
 			}
@@ -932,6 +915,7 @@ public class PartFluidInterface extends PartECBase implements IFluidHandler,
 						.postEvent(
 								new MENetworkCraftingPatternChange(this,
 										getGridNode()));
+				getHost().markForSave();
 			}
 		}
 		if (this.tank.getFluid() != null
@@ -942,62 +926,64 @@ public class PartFluidInterface extends PartECBase implements IFluidHandler,
 				IAEFluidStack notAdded = storage.getFluidInventory()
 						.injectItems(
 								AEApi.instance().storage()
-										.createFluidStack(s.copy()),
+										.createFluidStack(s),
 								Actionable.SIMULATE, new MachineSource(this));
-				if (notAdded != null) {
-					int toAdd = (int) (s.amount - notAdded.getStackSize());
-					storage.getFluidInventory().injectItems(
-							AEApi.instance()
-									.storage()
-									.createFluidStack(
-											this.tank.drain(toAdd, true)),
-							Actionable.MODULATE, new MachineSource(this));
-					this.doNextUpdate = true;
-					this.needBreake = false;
-				} else {
-					storage.getFluidInventory().injectItems(
-							AEApi.instance()
-									.storage()
-									.createFluidStack(
-											this.tank.drain(s.amount, true)),
-							Actionable.MODULATE, new MachineSource(this));
-					this.doNextUpdate = true;
-					this.needBreake = false;
+				int toAdd = s.amount;
+				IAEFluidStack actuallyNotInjected = storage.getFluidInventory().injectItems(
+					AEApi.instance()
+						.storage()
+						.createFluidStack(
+							this.tank.drain(toAdd, true)),
+					Actionable.MODULATE, new MachineSource(this));
+				if (actuallyNotInjected != null) {
+					int returned = this.tank.fill(actuallyNotInjected.getFluidStack(), true);
+					if (returned != actuallyNotInjected.getStackSize()) {
+						FMLLog.severe("[ExtraCells2] Interface tank import at %d:%d,%d,%d voided %d mL of %s",
+							tile.getWorldObj().provider.dimensionId,
+							tile.xCoord,
+							tile.yCoord,
+							tile.zCoord,
+							actuallyNotInjected.getStackSize() - returned,
+							actuallyNotInjected.getFluid().getName());
+					}
 				}
+				this.doNextUpdate = true;
+				this.needBreak = false;
 				didWork = true;
 			}
 		}
-		if ((this.tank.getFluid() == null || this.tank.getFluid().getFluid() == FluidRegistry
-				.getFluid(this.fluidFilter))
-				&& FluidRegistry.getFluid(this.fluidFilter) != null) {
+		if ((this.tank.getFluid() == null ||
+				(this.tank.getFluid().getFluid() == FluidRegistry
+					.getFluid(this.fluidFilter) && this.tank.getFluidAmount() < this.tank.getCapacity())
+			)
+			&& FluidRegistry.getFluid(this.fluidFilter) != null)
+		{
+			IAEFluidStack request = FluidUtil.createAEFluidStack(this.fluidFilter, 125 * TicksSinceLastCall);
 			IAEFluidStack extracted = storage.getFluidInventory().extractItems(
-					AEApi.instance()
-							.storage()
-							.createFluidStack(
-									new FluidStack(FluidRegistry
-											.getFluid(this.fluidFilter), 125 * TicksSinceLastCall)),
+					request,
 					Actionable.SIMULATE, new MachineSource(this));
 			if (extracted == null)
 				return TickRateModulation.SLOWER;
 			int accepted = this.tank.fill(extracted.getFluidStack(), false);
 			if (accepted == 0)
 				return TickRateModulation.SLOWER;
-			this.tank
-					.fill(storage
-							.getFluidInventory()
-							.extractItems(
-									AEApi.instance()
-											.storage()
-											.createFluidStack(
-													new FluidStack(
-															FluidRegistry
-																	.getFluid(this.fluidFilter),
-															accepted)),
-									Actionable.MODULATE,
-									new MachineSource(this)).getFluidStack(),
-							true);
+			request.setStackSize(Long.min(accepted, extracted.getStackSize()));
+			extracted = storage.getFluidInventory().extractItems(
+				request,
+				Actionable.MODULATE, new MachineSource(this));
+			accepted = this.tank.fill(extracted.getFluidStack(), true);
+			if (extracted.getStackSize() != accepted) {
+				// This should never happen, but log it in case it does
+				FMLLog.severe("[ExtraCells2] Interface tank export at %d:%d,%d,%d voided %d mL of %s",
+					tile.getWorldObj().provider.dimensionId,
+					tile.xCoord,
+					tile.yCoord,
+					tile.zCoord,
+					extracted.getStackSize() - accepted,
+					request.getFluid().getName());
+			}
 			this.doNextUpdate = true;
-			this.needBreake = false;
+			this.needBreak = false;
 			didWork = true;
 		}
 		return didWork ? TickRateModulation.URGENT : TickRateModulation.SLOWER;

--- a/src/main/scala/extracells/part/PartFluidInterface.java
+++ b/src/main/scala/extracells/part/PartFluidInterface.java
@@ -413,7 +413,7 @@ public class PartFluidInterface extends PartECBase implements IFluidHandler,
 
 	@Override
 	public TickingRequest getTickingRequest(IGridNode node) {
-		return new TickingRequest(1, 40, false, false);
+		return new TickingRequest(5, 120, false, false);
 	}
 
 	@Override

--- a/src/main/scala/extracells/part/PartFluidPlaneFormation.java
+++ b/src/main/scala/extracells/part/PartFluidPlaneFormation.java
@@ -131,7 +131,7 @@ public class PartFluidPlaneFormation extends PartECBase implements
 
 	@Override
 	public TickingRequest getTickingRequest(IGridNode node) {
-		return new TickingRequest(1, 20, false, false);
+		return new TickingRequest(2, 120, false, false);
 	}
 
 	public ECPrivateInventory getUpgradeInventory() {

--- a/src/main/scala/extracells/part/PartFluidStorage.java
+++ b/src/main/scala/extracells/part/PartFluidStorage.java
@@ -46,7 +46,7 @@ import java.util.List;
 
 public class PartFluidStorage extends PartECBase implements ICellContainer, IInventoryUpdateReceiver, IFluidSlotPartOrBlock {
 
-	private HashMap<FluidStack, Integer> fluidList = new HashMap<FluidStack, Integer>();
+	private HashMap<IAEFluidStack, Long> fluidList = new HashMap<IAEFluidStack, Long>();
 	private int priority = 0;
 	protected HandlerPartStorageFluid handler = new HandlerPartStorageFluid(this);
 	private Fluid[] filterFluids = new Fluid[54];
@@ -286,22 +286,20 @@ public class PartFluidStorage extends PartECBase implements ICellContainer, IInv
 		data.setTag("upgradeInventory", this.upgradeInventory.writeToNBT());
 		data.setString("access", this.access.name());
 	}
-	
+
 	private void updateNeighborFluids(){
 		fluidList.clear();
 		if(access == AccessRestriction.READ || access == AccessRestriction.READ_WRITE){
 			for(IAEFluidStack stack : handler.getAvailableItems(AEApi.instance().storage().createFluidList())){
-				FluidStack s = stack.getFluidStack().copy();
-				fluidList.put(s, s.amount);
+				fluidList.put(stack, stack.getStackSize());
 			}
 		}
 	}
-	
+
 	private boolean wasChanged(){
-		HashMap<FluidStack, Integer> fluids = new HashMap<FluidStack, Integer>();
+		HashMap<IAEFluidStack, Long> fluids = new HashMap<IAEFluidStack, Long>();
 		for(IAEFluidStack stack : handler.getAvailableItems(AEApi.instance().storage().createFluidList())){
-			FluidStack s = stack.getFluidStack();
-			fluids.put(s, s.amount);
+			fluids.put(stack, stack.getStackSize());
 		}
 		return !fluids.equals(fluidList);
 	}

--- a/src/main/scala/extracells/part/PartFluidTerminal.java
+++ b/src/main/scala/extracells/part/PartFluidTerminal.java
@@ -25,10 +25,12 @@ import extracells.util.inventory.ECPrivateInventory;
 import extracells.util.inventory.IInventoryUpdateReceiver;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.Vec3;
 import net.minecraftforge.common.util.ForgeDirection;
@@ -114,43 +116,77 @@ public class PartFluidTerminal extends PartECBase implements IGridTickable,
 		if (FluidUtil.isEmpty(container)) {
 			if (this.currentFluid == null)
 				return;
-			int capacity = FluidUtil.getCapacity(container, this.currentFluid);
-			IAEFluidStack result = monitor.extractItems(FluidUtil.createAEFluidStack(this.currentFluid, capacity), Actionable.SIMULATE, this.machineSource);
-			int proposedAmount = result == null ? 0 : (int) Math.min(capacity, result.getStackSize());
-			if(proposedAmount == 0)
+			FluidStack request = new FluidStack(this.currentFluid, Integer.MAX_VALUE);
+			MutablePair<ItemStack, FluidStack> simulation = FluidUtil.fillItemFromAe(container, request, monitor, Actionable.SIMULATE, this.machineSource);
+			if (simulation == null || simulation.getLeft() == null) {
 				return;
-			MutablePair<Integer, ItemStack> filledContainer = FluidUtil.fillStack(container, new FluidStack(this.currentFluid, proposedAmount));
-			if(filledContainer.getLeft() > proposedAmount)
-				return;
-			if (fillSecondSlot(filledContainer.getRight())) {
-				monitor.extractItems(FluidUtil.createAEFluidStack(this.currentFluid, filledContainer.getLeft()), Actionable.MODULATE, this.machineSource);
-				decreaseFirstSlot();
 			}
+			if (!fillSecondSlot(simulation.getLeft(), false)) {
+				return;
+			}
+			request.amount = simulation.getRight().amount;
+			MutablePair<ItemStack, FluidStack> result = FluidUtil.fillItemFromAe(container, request, monitor, Actionable.MODULATE, this.machineSource);
+			if (result == null || result.getLeft() == null) {
+				return;
+			}
+			if (!fillSecondSlot(result.getLeft(), true)) {
+				// Rare case: couldn't withdraw all requested fluid with AE, so a partially filled container can't stack with the other containers
+				TileEntity host = getHostTile();
+				if (host == null || host.getWorldObj() == null) {
+					return;
+				}
+				ForgeDirection side = getSide();
+				EntityItem overflow = new EntityItem(host.getWorldObj(),
+					host.xCoord + side.offsetX, host.yCoord + side.offsetY, host.zCoord + side.offsetZ,
+					result.getLeft());
+				host.getWorldObj().spawnEntityInWorld(overflow);
+			}
+			decreaseFirstSlot();
 		} else {
 			FluidStack containerFluid = FluidUtil.getFluidFromContainer(container);
-			IAEFluidStack notInjected = monitor.injectItems(FluidUtil.createAEFluidStack(containerFluid), Actionable.SIMULATE, this.machineSource);
-			if (notInjected != null)
+
+			ItemStack simulation = FluidUtil.drainItemIntoAe(container, monitor, Actionable.SIMULATE, this.machineSource);
+			if (simulation == null) {
 				return;
-			MutablePair<Integer, ItemStack> drainedContainer = FluidUtil.drainStack(container, containerFluid);
-			ItemStack emptyContainer = drainedContainer.getRight();
-			if (emptyContainer == null || fillSecondSlot(emptyContainer)) {
-				monitor.injectItems(FluidUtil.createAEFluidStack(containerFluid), Actionable.MODULATE, this.machineSource);
-				decreaseFirstSlot();
 			}
+			if (!fillSecondSlot(simulation, false)) {
+				return;
+			}
+			ItemStack result = FluidUtil.drainItemIntoAe(container, monitor, Actionable.MODULATE, this.machineSource);
+			if (result == null) {
+				return;
+			}
+			if (!fillSecondSlot(result, true)) {
+				// Rare case: couldn't withdraw all requested fluid with AE, so a partially filled container can't stack with the other containers
+				TileEntity host = getHostTile();
+				if (host == null || host.getWorldObj() == null) {
+					return;
+				}
+				ForgeDirection side = getSide();
+				EntityItem overflow = new EntityItem(host.getWorldObj(),
+					host.xCoord + side.offsetX, host.yCoord + side.offsetY, host.zCoord + side.offsetZ,
+					result);
+				host.getWorldObj().spawnEntityInWorld(overflow);
+			}
+			decreaseFirstSlot();
 		}
 	}
 
-	public boolean fillSecondSlot(ItemStack itemStack) {
+	public boolean fillSecondSlot(ItemStack itemStack, boolean doFill) {
 		if (itemStack == null)
 			return false;
 		ItemStack secondSlot = this.inventory.getStackInSlot(1);
 		if (secondSlot == null) {
-			this.inventory.setInventorySlotContents(1, itemStack);
+			if (doFill) {
+				this.inventory.setInventorySlotContents(1, itemStack);
+			}
 			return true;
 		} else {
 			if (!secondSlot.isItemEqual(itemStack) || !ItemStack.areItemStackTagsEqual(itemStack, secondSlot))
 				return false;
-			this.inventory.incrStackSize(1, itemStack.stackSize);
+			if (doFill) {
+				this.inventory.incrStackSize(1, itemStack.stackSize);
+			}
 			return true;
 		}
 	}

--- a/src/main/scala/extracells/part/PartFluidTerminal.java
+++ b/src/main/scala/extracells/part/PartFluidTerminal.java
@@ -219,7 +219,7 @@ public class PartFluidTerminal extends PartECBase implements IGridTickable,
 
 	@Override
 	public TickingRequest getTickingRequest(IGridNode node) {
-		return new TickingRequest(1, 20, false, false);
+		return new TickingRequest(2, 20, false, false);
 	}
 
 	@Override

--- a/src/main/scala/extracells/part/PartGasTerminal.scala
+++ b/src/main/scala/extracells/part/PartGasTerminal.scala
@@ -65,7 +65,7 @@ class PartGasTerminal extends PartFluidTerminal{
         this.inventory.setInventorySlotContents(0, filledContainer.getRight)
         monitor.extractItems(FluidUtil.createAEFluidStack(this.currentFluid, filledContainer.getLeft.toLong), Actionable.MODULATE, this.machineSource)
         doNextFill = true
-      }else if (fillSecondSlot(filledContainer.getRight)) {
+      }else if (fillSecondSlot(filledContainer.getRight, true)) {
         monitor.extractItems(FluidUtil.createAEFluidStack(this.currentFluid, filledContainer.getLeft.toLong), Actionable.MODULATE, this.machineSource)
         decreaseFirstSlot
         doNextFill = false
@@ -83,7 +83,7 @@ class PartGasTerminal extends PartFluidTerminal{
       if (emptyContainer != null && GasUtil.getGasFromContainer(emptyContainer) != null && emptyContainer.stackSize == 1) {
         monitor.injectItems(GasUtil.createAEFluidStack(gasStack), Actionable.MODULATE, this.machineSource)
         this.inventory.setInventorySlotContents(0, emptyContainer)
-      }else if (emptyContainer == null || fillSecondSlot(emptyContainer)) {
+      }else if (emptyContainer == null || fillSecondSlot(emptyContainer, true)) {
         monitor.injectItems(GasUtil.createAEFluidStack(containerGas), Actionable.MODULATE, this.machineSource)
         decreaseFirstSlot
       }

--- a/src/main/scala/extracells/part/PartOreDictExporter.java
+++ b/src/main/scala/extracells/part/PartOreDictExporter.java
@@ -323,7 +323,7 @@ public class PartOreDictExporter extends PartECBase implements IGridTickable {
 
 	@Override
 	public final TickingRequest getTickingRequest(IGridNode node) {
-		return new TickingRequest(1, 20, false, false);
+		return new TickingRequest(5, 60, false, false);
 	}
 
 	@Override

--- a/src/main/scala/extracells/tileentity/TileEntityFluidInterface.java
+++ b/src/main/scala/extracells/tileentity/TileEntityFluidInterface.java
@@ -867,14 +867,14 @@ public class TileEntityFluidInterface extends TileBase implements
 			if (tank.getFluid() != null
 				&& FluidRegistry.getFluid(this.fluidFilter[i]) != tank
 				.getFluid().getFluid()) {
-				FluidStack s = tank.drain(125, false);
+				FluidStack s = tank.drain(1000, false);
 				if (s != null) {
 					IAEFluidStack notAdded = storage.getFluidInventory()
 						.injectItems(
 							AEApi.instance().storage()
 								.createFluidStack(s),
 							Actionable.SIMULATE, new MachineSource(this));
-					int toAdd = s.amount;
+					int toAdd = s.amount - (notAdded != null ? (int)notAdded.getStackSize() : 0);
 					IAEFluidStack actuallyNotInjected = storage.getFluidInventory().injectItems(
 						AEApi.instance()
 							.storage()
@@ -902,7 +902,7 @@ public class TileEntityFluidInterface extends TileBase implements
 			)
 				&& FluidRegistry.getFluid(this.fluidFilter[i]) != null)
 			{
-				IAEFluidStack request = FluidUtil.createAEFluidStack(this.fluidFilter[i], 125);
+				IAEFluidStack request = FluidUtil.createAEFluidStack(this.fluidFilter[i], 1000);
 				IAEFluidStack extracted = storage.getFluidInventory().extractItems(
 					request,
 					Actionable.SIMULATE, new MachineSource(this));
@@ -915,6 +915,9 @@ public class TileEntityFluidInterface extends TileBase implements
 				extracted = storage.getFluidInventory().extractItems(
 					request,
 					Actionable.MODULATE, new MachineSource(this));
+				if (extracted == null || extracted.getStackSize() <= 0) {
+					continue;
+				}
 				accepted = tank.fill(extracted.getFluidStack(), true);
 				if (extracted.getStackSize() != accepted) {
 					// This should never happen, but log it in case it does

--- a/src/main/scala/extracells/tileentity/TileEntityFluidInterface.java
+++ b/src/main/scala/extracells/tileentity/TileEntityFluidInterface.java
@@ -905,6 +905,7 @@ public class TileEntityFluidInterface extends TileBase implements
 			}
 			if ((this.tanks[i].getFluid() == null || this.tanks[i].getFluid()
 					.getFluid() == FluidRegistry.getFluid(this.fluidFilter[i]))
+					&& this.tanks[i].getFluidAmount() < this.tanks[i].getCapacity()
 					&& FluidRegistry.getFluid(this.fluidFilter[i]) != null) {
 				IAEFluidStack extracted = storage
 						.getFluidInventory()

--- a/src/main/scala/extracells/tileentity/TileEntityFluidInterface.java
+++ b/src/main/scala/extracells/tileentity/TileEntityFluidInterface.java
@@ -14,6 +14,7 @@ import appeng.api.networking.security.BaseActionSource;
 import appeng.api.networking.security.IActionHost;
 import appeng.api.networking.security.MachineSource;
 import appeng.api.networking.storage.IStorageGrid;
+import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.IStorageMonitorable;
 import appeng.api.storage.data.IAEFluidStack;
@@ -22,6 +23,7 @@ import appeng.api.storage.data.IAEStack;
 import appeng.api.util.AECableType;
 import appeng.api.util.DimensionalCoord;
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.FMLLog;
 import extracells.api.IECTileEntity;
 import extracells.api.IFluidInterface;
 import extracells.api.crafting.IFluidCraftingPatternDetails;
@@ -33,6 +35,7 @@ import extracells.integration.waila.IWailaTile;
 import extracells.network.packet.other.IFluidSlotPartOrBlock;
 import extracells.registries.ItemEnum;
 import extracells.util.EmptyMeItemMonitor;
+import extracells.util.FluidUtil;
 import extracells.util.ItemUtils;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
@@ -305,17 +308,9 @@ public class TileEntityFluidInterface extends TileBase implements
 		IStorageGrid storage = grid.getCache(IStorageGrid.class);
 		if (storage == null)
 			return 0;
-		IAEFluidStack notRemoved;
-		FluidStack copy = resource.copy();
-		if (doFill) {
-			notRemoved = storage.getFluidInventory().injectItems(
-					AEApi.instance().storage().createFluidStack(resource),
-					Actionable.MODULATE, new MachineSource(this));
-		} else {
-			notRemoved = storage.getFluidInventory().injectItems(
-					AEApi.instance().storage().createFluidStack(resource),
-					Actionable.SIMULATE, new MachineSource(this));
-		}
+		IAEFluidStack notRemoved = storage.getFluidInventory().injectItems(
+			AEApi.instance().storage().createFluidStack(resource),
+			doFill ? Actionable.MODULATE : Actionable.SIMULATE, new MachineSource(this));
 		if (notRemoved == null)
 			return resource.amount;
 		return (int) (resource.amount - notRemoved.getStackSize());
@@ -696,7 +691,7 @@ public class TileEntityFluidInterface extends TileBase implements
 										.storage()
 										.createFluidStack(
 												new FluidStack(fluid,
-														(int) (amount + 0))),
+													amount.intValue())),
 								Actionable.SIMULATE, new MachineSource(this));
 				if (extractFluid == null
 						|| extractFluid.getStackSize() != amount) {
@@ -711,7 +706,7 @@ public class TileEntityFluidInterface extends TileBase implements
 										.storage()
 										.createFluidStack(
 												new FluidStack(fluid,
-														(int) (amount + 0))),
+														amount.intValue())),
 								Actionable.MODULATE, new MachineSource(this));
 				this.export.add(extractFluid.copy());
 			}
@@ -868,78 +863,70 @@ public class TileEntityFluidInterface extends TileBase implements
 			this.toExport = null;
 		}
 		for (int i = 0; i < this.tanks.length; i++) {
-			if (this.tanks[i].getFluid() != null
-					&& FluidRegistry.getFluid(this.fluidFilter[i]) != this.tanks[i]
-							.getFluid().getFluid()) {
-				FluidStack s = this.tanks[i].drain(125, false);
+			FluidTank tank = this.tanks[i];
+			if (tank.getFluid() != null
+				&& FluidRegistry.getFluid(this.fluidFilter[i]) != tank
+				.getFluid().getFluid()) {
+				FluidStack s = tank.drain(125, false);
 				if (s != null) {
 					IAEFluidStack notAdded = storage.getFluidInventory()
-							.injectItems(
-									AEApi.instance().storage()
-											.createFluidStack(s.copy()),
-									Actionable.SIMULATE,
-									new MachineSource(this));
-					if (notAdded != null) {
-						int toAdd = (int) (s.amount - notAdded.getStackSize());
-						storage.getFluidInventory().injectItems(
-								AEApi.instance()
-										.storage()
-										.createFluidStack(
-												this.tanks[i]
-														.drain(toAdd, true)),
-								Actionable.MODULATE, new MachineSource(this));
-						this.doNextUpdate = true;
-						this.wasIdle = false;
-					} else {
-						storage.getFluidInventory().injectItems(
-								AEApi.instance()
-										.storage()
-										.createFluidStack(
-												this.tanks[i].drain(s.amount,
-														true)),
-								Actionable.MODULATE, new MachineSource(this));
-						this.doNextUpdate = true;
-						this.wasIdle = false;
+						.injectItems(
+							AEApi.instance().storage()
+								.createFluidStack(s),
+							Actionable.SIMULATE, new MachineSource(this));
+					int toAdd = s.amount;
+					IAEFluidStack actuallyNotInjected = storage.getFluidInventory().injectItems(
+						AEApi.instance()
+							.storage()
+							.createFluidStack(
+								tank.drain(toAdd, true)),
+						Actionable.MODULATE, new MachineSource(this));
+					if (actuallyNotInjected != null) {
+						int returned = tank.fill(actuallyNotInjected.getFluidStack(), true);
+						if (returned != actuallyNotInjected.getStackSize()) {
+							FMLLog.severe("[ExtraCells2] Interface tank import at %d:%d,%d,%d voided %d mL of %s",
+								this.getWorldObj().provider.dimensionId,
+								this.xCoord,
+								this.yCoord,
+								this.zCoord,
+								actuallyNotInjected.getStackSize() - returned,
+								actuallyNotInjected.getFluid().getName());
+						}
 					}
+					this.doNextUpdate = true;
 				}
 			}
-			if ((this.tanks[i].getFluid() == null || this.tanks[i].getFluid()
-					.getFluid() == FluidRegistry.getFluid(this.fluidFilter[i]))
-					&& this.tanks[i].getFluidAmount() < this.tanks[i].getCapacity()
-					&& FluidRegistry.getFluid(this.fluidFilter[i]) != null) {
-				IAEFluidStack extracted = storage
-						.getFluidInventory()
-						.extractItems(
-								AEApi.instance()
-										.storage()
-										.createFluidStack(
-												new FluidStack(
-														FluidRegistry
-																.getFluid(this.fluidFilter[i]),
-														125)),
-								Actionable.SIMULATE, new MachineSource(this));
+			if ((tank.getFluid() == null ||
+				(tank.getFluid().getFluid() == FluidRegistry
+					.getFluid(this.fluidFilter[i]) && tank.getFluidAmount() < tank.getCapacity())
+			)
+				&& FluidRegistry.getFluid(this.fluidFilter[i]) != null)
+			{
+				IAEFluidStack request = FluidUtil.createAEFluidStack(this.fluidFilter[i], 125);
+				IAEFluidStack extracted = storage.getFluidInventory().extractItems(
+					request,
+					Actionable.SIMULATE, new MachineSource(this));
 				if (extracted == null)
 					continue;
-				int accepted = this.tanks[i].fill(extracted.getFluidStack(),
-						false);
+				int accepted = tank.fill(extracted.getFluidStack(), false);
 				if (accepted == 0)
 					continue;
-				this.tanks[i]
-						.fill(storage
-								.getFluidInventory()
-								.extractItems(
-										AEApi.instance()
-												.storage()
-												.createFluidStack(
-														new FluidStack(
-																FluidRegistry
-																		.getFluid(this.fluidFilter[i]),
-																accepted)),
-										Actionable.MODULATE,
-										new MachineSource(this))
-								.getFluidStack(), true);
+				request.setStackSize(Long.min(accepted, extracted.getStackSize()));
+				extracted = storage.getFluidInventory().extractItems(
+					request,
+					Actionable.MODULATE, new MachineSource(this));
+				accepted = tank.fill(extracted.getFluidStack(), true);
+				if (extracted.getStackSize() != accepted) {
+					// This should never happen, but log it in case it does
+					FMLLog.severe("[ExtraCells2] Interface tank export at %d:%d,%d,%d voided %d mL of %s",
+						this.getWorldObj().provider.dimensionId,
+						this.xCoord,
+						this.yCoord,
+						this.zCoord,
+						extracted.getStackSize() - accepted,
+						request.getFluid().getName());
+				}
 				this.doNextUpdate = true;
-				this.wasIdle = false;
 			}
 		}
 	}


### PR DESCRIPTION
A relatively big rewrite of the core fluid import/export/containerisation code to handle failures and partial transactions where possible, instead of blindly assuming everything works and thus duplicating items like before.

This should get rid of all the major fluid/item duplication bugs in EC2, fingers crossed; but the code is complex so it's quite likely I made mistakes somewhere. I tested this against the known dupes in EC2 and it fixes them.