### PR TITLE
Update some features

### DIFF
--- a/src/main/scala/extracells/Extracells.scala
+++ b/src/main/scala/extracells/Extracells.scala
@@ -1,7 +1,5 @@
 package extracells
 
-import java.io.File
-
 import appeng.api.AEApi
 import cpw.mods.fml.client.registry.RenderingRegistry
 import cpw.mods.fml.common.Mod.EventHandler
@@ -13,13 +11,14 @@ import extracells.network.{ChannelHandler, GuiHandler}
 import extracells.proxy.CommonProxy
 import extracells.registries.ItemEnum
 import extracells.render.RenderHandler
-import extracells.util.{ExtraCellsEventHandler, FluidCellHandler, NameHandler}
-import extracells.util.AdvancedCellHandler
+import extracells.util.{AdvancedCellHandler, ExtraCellsEventHandler, FluidCellHandler, NameHandler}
 import extracells.wireless.AEWirelessTermHandler
 import net.minecraft.creativetab.CreativeTabs
 import net.minecraft.item.ItemStack
 import net.minecraftforge.common.MinecraftForge
 import net.minecraftforge.common.config.Configuration
+
+import java.io.File
 
 @Mod(modid = "extracells", name = "Extra Cells", version = "GRADLETOKEN_VERSION", modLanguage = "scala", dependencies = "after:LogisticsPipes|Main;after:Waila;required-after:appliedenergistics2")
 object Extracells {
@@ -31,12 +30,12 @@ object Extracells {
 	var VERSION = ""
 
 	var bcBurnTimeMultiplicator = 4
-
+	var terminalUpdateInterval = 20
 	var configFolder: File = null
 	var shortenedBuckets = true
 	var dynamicTypes = true
 	val integration = new Integration
-	
+
 	val ModTab = new CreativeTabs("Extra_Cells") {
 		override def getIconItemStack = new ItemStack(ItemEnum.FLUIDSTORAGE.getItem)
 		override def getTabIconItem = ItemEnum.FLUIDSTORAGE.getItem
@@ -78,6 +77,7 @@ object Extracells {
 		config.load()
 		shortenedBuckets = config.get("Tooltips", "shortenedBuckets", true, "Shall the guis shorten large mB values?").getBoolean(true)
 		dynamicTypes = config.get("Storage Cells", "dynamicTypes", true, "Should the mount of bytes needed for a new type depend on the cellsize?").getBoolean(true)
+		terminalUpdateInterval = config.get("Terminal", "Interval", 20, "How often is the fluid in the terminal updated?").getInt(20)
 		integration.loadConfig(config)
 
 		config.save()

--- a/src/main/scala/extracells/Extracells.scala
+++ b/src/main/scala/extracells/Extracells.scala
@@ -28,7 +28,7 @@ object Extracells {
 	var proxy: CommonProxy = null
 
 	var VERSION = ""
-
+	var basePartSpeed = 125
 	var bcBurnTimeMultiplicator = 4
 	var terminalUpdateInterval = 20
 	var configFolder: File = null
@@ -78,6 +78,8 @@ object Extracells {
 		shortenedBuckets = config.get("Tooltips", "shortenedBuckets", true, "Shall the guis shorten large mB values?").getBoolean(true)
 		dynamicTypes = config.get("Storage Cells", "dynamicTypes", true, "Should the mount of bytes needed for a new type depend on the cellsize?").getBoolean(true)
 		terminalUpdateInterval = config.get("Terminal", "Interval", 20, "How often is the fluid in the terminal updated?").getInt(20)
+		basePartSpeed = config.get("BaseFluidPart", "Interval", 125, "Base fluid part import export speed ").getInt(125)
+
 		integration.loadConfig(config)
 
 		config.save()

--- a/src/main/scala/extracells/container/ContainerFluidStorage.java
+++ b/src/main/scala/extracells/container/ContainerFluidStorage.java
@@ -9,8 +9,6 @@ import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.IMEMonitorHandlerReceiver;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IItemList;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import extracells.api.ECApi;
 import extracells.api.IPortableFluidStorageCell;
 import extracells.api.IWirelessFluidTermHandler;
@@ -23,8 +21,6 @@ import extracells.network.packet.part.PacketFluidStorage;
 import extracells.util.FluidUtil;
 import extracells.util.inventory.ECPrivateInventory;
 import extracells.util.inventory.IInventoryUpdateReceiver;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Gui;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
@@ -425,18 +421,19 @@ public class ContainerFluidStorage extends Container implements
 			this.guiFluidStorage.updateFluids();
 	}
 
-	@SideOnly(Side.CLIENT)
+
 	public void updateFluidList(IItemList<IAEFluidStack> _fluidStackList, boolean incremental) {
 		if (incremental) {
-			Gui gui = Minecraft.getMinecraft().currentScreen;
-			ContainerFluidStorage container = (ContainerFluidStorage) ((GuiFluidStorage) gui).inventorySlots;
-			IItemList<IAEFluidStack> temp = container.getFluidStackList();
+			IItemList<IAEFluidStack> temp = this.getFluidStackList();
 			for (IAEFluidStack f1 : _fluidStackList) {
+				boolean change = false;
 				for (IAEFluidStack f2 : temp) {
 					if (f1.getFluid().getID() == f2.getFluid().getID()) {
 						f2.setStackSize(f2.getStackSize() + f1.getStackSize());
+						change = true;
 					}
 				}
+				if (!change) temp.add(f1);
 			}
 			this.fluidStackList = temp;
 		} else {

--- a/src/main/scala/extracells/container/ContainerFluidTerminal.java
+++ b/src/main/scala/extracells/container/ContainerFluidTerminal.java
@@ -9,8 +9,6 @@ import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.IMEMonitorHandlerReceiver;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IItemList;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import extracells.api.ECApi;
 import extracells.container.slot.SlotRespective;
 import extracells.gui.GuiFluidTerminal;
@@ -19,8 +17,6 @@ import extracells.network.packet.part.PacketFluidTerminal;
 import extracells.part.PartFluidTerminal;
 import extracells.util.FluidUtil;
 import extracells.util.PermissionUtil;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Gui;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -235,18 +231,18 @@ public class ContainerFluidTerminal extends Container implements
 			this.guiFluidTerminal.updateFluids();
 	}
 
-	@SideOnly(Side.CLIENT)
 	public void updateFluidList(IItemList<IAEFluidStack> _fluidStackList, boolean incremental) {
 		if (incremental) {
-			Gui gui = Minecraft.getMinecraft().currentScreen;
-			ContainerFluidTerminal container = (ContainerFluidTerminal) ((GuiFluidTerminal) gui).inventorySlots;
-			IItemList<IAEFluidStack> temp = container.getFluidStackList();
+			IItemList<IAEFluidStack> temp = this.getFluidStackList();
 			for (IAEFluidStack f1 : _fluidStackList) {
+				boolean change = false;
 				for (IAEFluidStack f2 : temp) {
 					if (f1.getFluid().getID() == f2.getFluid().getID()) {
 						f2.setStackSize(f2.getStackSize() + f1.getStackSize());
+						change = true;
 					}
 				}
+				if (!change) temp.add(f1);
 			}
 			this.fluidStackList = temp;
 		} else {

--- a/src/main/scala/extracells/container/ContainerGasStorage.java
+++ b/src/main/scala/extracells/container/ContainerGasStorage.java
@@ -10,8 +10,6 @@ import appeng.api.storage.IMEMonitorHandlerReceiver;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IItemList;
 import cpw.mods.fml.common.Optional;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import extracells.api.IPortableGasStorageCell;
 import extracells.api.IWirelessGasTermHandler;
 import extracells.container.slot.SlotPlayerInventory;
@@ -26,8 +24,6 @@ import extracells.util.GasUtil;
 import extracells.util.inventory.ECPrivateInventory;
 import extracells.util.inventory.IInventoryUpdateReceiver;
 import mekanism.api.gas.GasStack;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Gui;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.Container;
@@ -425,18 +421,18 @@ public class ContainerGasStorage extends Container implements
 			this.guiGasStorage.updateFluids();
 	}
 
-	@SideOnly(Side.CLIENT)
 	public void updateFluidList(IItemList<IAEFluidStack> _fluidStackList, boolean incremental) {
 		if (incremental) {
-			Gui gui = Minecraft.getMinecraft().currentScreen;
-			ContainerGasStorage container = (ContainerGasStorage) ((GuiGasStorage) gui).inventorySlots;
-			IItemList<IAEFluidStack> temp = container.getFluidStackList();
+			IItemList<IAEFluidStack> temp = this.getFluidStackList();
 			for (IAEFluidStack f1 : _fluidStackList) {
+				boolean change = false;
 				for (IAEFluidStack f2 : temp) {
 					if (f1.getFluid().getID() == f2.getFluid().getID()) {
 						f2.setStackSize(f2.getStackSize() + f1.getStackSize());
+						change = true;
 					}
 				}
+				if (!change) temp.add(f1);
 			}
 			this.fluidStackList = temp;
 		} else {

--- a/src/main/scala/extracells/container/ContainerGasTerminal.java
+++ b/src/main/scala/extracells/container/ContainerGasTerminal.java
@@ -9,6 +9,8 @@ import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.IMEMonitorHandlerReceiver;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IItemList;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import extracells.container.slot.SlotRespective;
 import extracells.gui.GuiGasTerminal;
 import extracells.gui.widget.fluid.IFluidSelectorContainer;
@@ -17,6 +19,8 @@ import extracells.part.PartFluidTerminal;
 import extracells.part.PartGasTerminal;
 import extracells.util.GasUtil;
 import extracells.util.PermissionUtil;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Gui;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -29,12 +33,12 @@ import net.minecraftforge.fluids.Fluid;
 public class ContainerGasTerminal extends Container implements
 		IMEMonitorHandlerReceiver<IAEFluidStack>, IFluidSelectorContainer {
 
-	private PartGasTerminal terminal;
+	private final PartGasTerminal terminal;
 	private IMEMonitor<IAEFluidStack> monitor;
 	private IItemList<IAEFluidStack> fluidStackList = AEApi.instance()
 			.storage().createFluidList();
 	private Fluid selectedFluid;
-	private EntityPlayer player;
+	private final EntityPlayer player;
 	private GuiGasTerminal guiGasTerminal;
 
 	public ContainerGasTerminal(PartGasTerminal _terminal, EntityPlayer _player) {
@@ -202,6 +206,27 @@ public class ContainerGasTerminal extends Container implements
 
 	public void updateFluidList(IItemList<IAEFluidStack> _fluidStackList) {
 		this.fluidStackList = _fluidStackList;
+		if (this.guiGasTerminal != null)
+			this.guiGasTerminal.updateFluids();
+	}
+
+	@SideOnly(Side.CLIENT)
+	public void updateFluidList(IItemList<IAEFluidStack> _fluidStackList, boolean incremental) {
+		if (incremental) {
+			Gui gui = Minecraft.getMinecraft().currentScreen;
+			ContainerGasTerminal container = (ContainerGasTerminal) ((GuiGasTerminal) gui).inventorySlots;
+			IItemList<IAEFluidStack> temp = container.getFluidStackList();
+			for (IAEFluidStack f1 : _fluidStackList) {
+				for (IAEFluidStack f2 : temp) {
+					if (f1.getFluid().getID() == f2.getFluid().getID()) {
+						f2.setStackSize(f2.getStackSize() + f1.getStackSize());
+					}
+				}
+			}
+			this.fluidStackList = temp;
+		} else {
+			this.fluidStackList = _fluidStackList;
+		}
 		if (this.guiGasTerminal != null)
 			this.guiGasTerminal.updateFluids();
 	}

--- a/src/main/scala/extracells/container/ContainerGasTerminal.java
+++ b/src/main/scala/extracells/container/ContainerGasTerminal.java
@@ -9,8 +9,6 @@ import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.IMEMonitorHandlerReceiver;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IItemList;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import extracells.container.slot.SlotRespective;
 import extracells.gui.GuiGasTerminal;
 import extracells.gui.widget.fluid.IFluidSelectorContainer;
@@ -19,8 +17,6 @@ import extracells.part.PartFluidTerminal;
 import extracells.part.PartGasTerminal;
 import extracells.util.GasUtil;
 import extracells.util.PermissionUtil;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Gui;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.entity.player.InventoryPlayer;
@@ -210,18 +206,18 @@ public class ContainerGasTerminal extends Container implements
 			this.guiGasTerminal.updateFluids();
 	}
 
-	@SideOnly(Side.CLIENT)
 	public void updateFluidList(IItemList<IAEFluidStack> _fluidStackList, boolean incremental) {
 		if (incremental) {
-			Gui gui = Minecraft.getMinecraft().currentScreen;
-			ContainerGasTerminal container = (ContainerGasTerminal) ((GuiGasTerminal) gui).inventorySlots;
-			IItemList<IAEFluidStack> temp = container.getFluidStackList();
+			IItemList<IAEFluidStack> temp = this.getFluidStackList();
 			for (IAEFluidStack f1 : _fluidStackList) {
+				boolean change = false;
 				for (IAEFluidStack f2 : temp) {
 					if (f1.getFluid().getID() == f2.getFluid().getID()) {
 						f2.setStackSize(f2.getStackSize() + f1.getStackSize());
+						change = true;
 					}
 				}
+				if (!change) temp.add(f1);
 			}
 			this.fluidStackList = temp;
 		} else {

--- a/src/main/scala/extracells/gui/GuiFluidStorage.java
+++ b/src/main/scala/extracells/gui/GuiFluidStorage.java
@@ -59,8 +59,6 @@ public class GuiFluidStorage extends GuiContainer implements IFluidSelectorGui {
 		drawTexturedModalRect(this.guiLeft, this.guiTop, 0, 0, this.xSize,
 			this.ySize);
 		this.searchbar.drawTextBox();
-		new PacketFluidStorage(this.player).sendPacketToServer();
-
 	}
 
 	protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY) {

--- a/src/main/scala/extracells/gui/GuiFluidStorage.java
+++ b/src/main/scala/extracells/gui/GuiFluidStorage.java
@@ -57,11 +57,12 @@ public class GuiFluidStorage extends GuiContainer implements IFluidSelectorGui {
 		GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
 		Minecraft.getMinecraft().renderEngine.bindTexture(this.guiTexture);
 		drawTexturedModalRect(this.guiLeft, this.guiTop, 0, 0, this.xSize,
-				this.ySize);
+			this.ySize);
 		this.searchbar.drawTextBox();
+		new PacketFluidStorage(this.player).sendPacketToServer();
+
 	}
 
-	@Override
 	protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY) {
 		this.fontRendererObj
 				.drawString(StatCollector.translateToLocal(this.guiName)

--- a/src/main/scala/extracells/gui/GuiGasStorage.java
+++ b/src/main/scala/extracells/gui/GuiGasStorage.java
@@ -26,15 +26,14 @@ import java.util.List;
 
 public class GuiGasStorage extends GuiContainer implements IFluidSelectorGui {
 
-	private EntityPlayer player;
+	private final EntityPlayer player;
 	private int currentScroll = 0;
 	private GuiTextField searchbar;
 	private List<AbstractFluidWidget> fluidWidgets = new ArrayList<AbstractFluidWidget>();
-	private ResourceLocation guiTexture = new ResourceLocation("extracells", "textures/gui/terminalfluid.png");
+	private final ResourceLocation guiTexture = new ResourceLocation("extracells", "textures/gui/terminalfluid.png");
 	public IAEFluidStack currentFluid;
-	private ContainerGasStorage containerGasStorage;
+	private final ContainerGasStorage containerGasStorage;
 	private final String guiName;
-	private int deltaWheel = 0;
 
 	public GuiGasStorage(EntityPlayer _player, String _guiName) {
 		super(new ContainerGasStorage(_player));
@@ -50,7 +49,7 @@ public class GuiGasStorage extends GuiContainer implements IFluidSelectorGui {
 	@Override
 	public void handleMouseInput() {
 		super.handleMouseInput();
-		deltaWheel = Mouse.getEventDWheel();
+		int deltaWheel = Mouse.getEventDWheel();
 		if (deltaWheel < 0) {
 			currentScroll++;
 		} else if (deltaWheel > 0) {
@@ -74,15 +73,14 @@ public class GuiGasStorage extends GuiContainer implements IFluidSelectorGui {
 		drawWidgets(mouseX, mouseY);
 		if (this.currentFluid != null) {
 			long currentFluidAmount = this.currentFluid.getStackSize();
-			String amountToText = Long.toString(currentFluidAmount) + "mB";
+			String amountToText = currentFluidAmount + "mB";
 			if (Extracells.shortenedBuckets()) {
 				if (currentFluidAmount > 1000000000L)
-					amountToText = Long
-							.toString(currentFluidAmount / 1000000000L)
-							+ "Mega";
+					amountToText = currentFluidAmount / 1000000000L
+						+ "Mega";
 				else if (currentFluidAmount > 1000000L)
-					amountToText = Long.toString(currentFluidAmount / 1000000L)
-							+ "Kilo";
+					amountToText = currentFluidAmount / 1000000L
+						+ "Kilo";
 				else if (currentFluidAmount > 9999L) {
 					amountToText = Long.toString(currentFluidAmount / 1000L);
 				}
@@ -161,17 +159,17 @@ public class GuiGasStorage extends GuiContainer implements IFluidSelectorGui {
 		updateFluids();
 		Collections.sort(this.fluidWidgets, new FluidWidgetComparator());
 		this.searchbar = new GuiTextField(this.fontRendererObj,
-				this.guiLeft + 81, this.guiTop + 6, 88, 10) {
+			this.guiLeft + 81, this.guiTop + 6, 88, 10) {
 
-			private int xPos = 0;
-			private int yPos = 0;
-			private int width = 0;
-			private int height = 0;
+			private final int xPos = 0;
+			private final int yPos = 0;
+			private final int width = 0;
+			private final int height = 0;
 
 			@Override
 			public void mouseClicked(int x, int y, int mouseBtn) {
 				boolean flag = x >= this.xPos && x < this.xPos + this.width
-						&& y >= this.yPos && y < this.yPos + this.height;
+					&& y >= this.yPos && y < this.yPos + this.height;
 				if (flag && mouseBtn == 3)
 					setText("");
 			}

--- a/src/main/scala/extracells/gui/GuiGasTerminal.java
+++ b/src/main/scala/extracells/gui/GuiGasTerminal.java
@@ -28,15 +28,14 @@ import java.util.List;
 
 public class GuiGasTerminal extends GuiContainer implements IFluidSelectorGui {
 
-	private PartFluidTerminal terminal;
-	private EntityPlayer player;
+	private final PartFluidTerminal terminal;
+	private final EntityPlayer player;
 	private int currentScroll = 0;
 	private GuiTextField searchbar;
 	private List<AbstractFluidWidget> fluidWidgets = new ArrayList<AbstractFluidWidget>();
-	private ResourceLocation guiTexture = new ResourceLocation("extracells", "textures/gui/terminalfluid.png");
+	private final ResourceLocation guiTexture = new ResourceLocation("extracells", "textures/gui/terminalfluid.png");
 	public IAEFluidStack currentFluid;
-	private ContainerGasTerminal containerTerminalFluid;
-	private int deltaWheel = 0;
+	private final ContainerGasTerminal containerTerminalFluid;
 
 	public GuiGasTerminal(PartGasTerminal _terminal, EntityPlayer _player) {
 		super(new ContainerGasTerminal(_terminal, _player));
@@ -63,14 +62,14 @@ public class GuiGasTerminal extends GuiContainer implements IFluidSelectorGui {
 		drawWidgets(mouseX, mouseY);
 		if (this.currentFluid != null) {
 			long currentFluidAmount = this.currentFluid.getStackSize();
-			String amountToText = Long.toString(currentFluidAmount) + "mB";
+			String amountToText = currentFluidAmount + "mB";
 			if (Extracells.shortenedBuckets()) {
 				if (currentFluidAmount > 1000000000L)
-					amountToText = Long.toString(currentFluidAmount / 1000000000L) + "MegaB";
+					amountToText = currentFluidAmount / 1000000000L + "MegaB";
 				else if (currentFluidAmount > 1000000L)
-					amountToText = Long.toString(currentFluidAmount / 1000000L) + "KiloB";
+					amountToText = currentFluidAmount / 1000000L + "KiloB";
 				else if (currentFluidAmount > 9999L) {
-					amountToText = Long.toString(currentFluidAmount / 1000L) + "B";
+					amountToText = currentFluidAmount / 1000L + "B";
 				}
 			}
 
@@ -84,7 +83,7 @@ public class GuiGasTerminal extends GuiContainer implements IFluidSelectorGui {
 	@Override
 	public void handleMouseInput() {
 		super.handleMouseInput();
-		deltaWheel = Mouse.getEventDWheel();
+		int deltaWheel = Mouse.getEventDWheel();
 		if (deltaWheel < 0) {
 			currentScroll++;
 		} else if (deltaWheel > 0) {
@@ -157,12 +156,12 @@ public class GuiGasTerminal extends GuiContainer implements IFluidSelectorGui {
 		updateFluids();
 		Collections.sort(this.fluidWidgets, new FluidWidgetComparator());
 		this.searchbar = new GuiTextField(this.fontRendererObj,
-				this.guiLeft + 81, this.guiTop + 6, 88, 10) {
+			this.guiLeft + 81, this.guiTop + 6, 88, 10) {
 
-			private int xPos = 0;
-			private int yPos = 0;
-			private int width = 0;
-			private int height = 0;
+			private final int xPos = 0;
+			private final int yPos = 0;
+			private final int width = 0;
+			private final int height = 0;
 
 			@Override
 			public void mouseClicked(int x, int y, int mouseBtn) {

--- a/src/main/scala/extracells/gui/GuiOreDictExport.java
+++ b/src/main/scala/extracells/gui/GuiOreDictExport.java
@@ -111,7 +111,7 @@ public class GuiOreDictExport extends GuiContainer {
 			this.fontRendererObj.drawString(
 				StatCollector.translateToLocal("container.inventory"), 8,
 				this.ySize - 94, 0x000000);
-		if (!filter.isEmpty() && !filter.startsWith("*")) {
+		if (!filter.isEmpty() && !filter.startsWith("*") && !filter.startsWith("^") && !filter.startsWith("$")) {
 			this._containerOreDictExport.part.setFilter(filter, false);
 			Iterator<AEItemStack> items = this._containerOreDictExport.part.getOres().iterator();
 			int size = this._containerOreDictExport.part.getOres().size();

--- a/src/main/scala/extracells/gui/GuiOreDictExport.java
+++ b/src/main/scala/extracells/gui/GuiOreDictExport.java
@@ -18,14 +18,13 @@ import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 
-import java.util.*;
+import java.util.Iterator;
 
 
 public class GuiOreDictExport extends GuiContainer {
 
 	public ContainerOreDictExport _containerOreDictExport;
 	private int currentScroll = 0;
-	private int deltaWheel = 0;
 	public static void updateFilter(String _filter) {
 		if (filter != null) {
 			filter = _filter;
@@ -38,9 +37,9 @@ public class GuiOreDictExport extends GuiContainer {
 		}
 	}
 
-	private ResourceLocation guiTexture = new ResourceLocation("extracells",
-			"textures/gui/oredictexport.png");
-	private EntityPlayer player;
+	private final ResourceLocation guiTexture = new ResourceLocation("extracells",
+		"textures/gui/oredictexport.png");
+	private final EntityPlayer player;
 	private static String filter = "";
 
 	private GuiTextField searchbar;
@@ -60,7 +59,7 @@ public class GuiOreDictExport extends GuiContainer {
 	@Override
 	public void handleMouseInput() {
 		super.handleMouseInput();
-		deltaWheel = Mouse.getEventDWheel();
+		int deltaWheel = Mouse.getEventDWheel();
 		if (deltaWheel < 0) {
 			currentScroll++;
 		} else if (deltaWheel > 0) {
@@ -105,7 +104,6 @@ public class GuiOreDictExport extends GuiContainer {
 	@Override
 	protected void drawGuiContainerForegroundLayer(int mouseX, int mouseY) {
 		super.drawGuiContainerForegroundLayer(mouseX, mouseY);
-		if (!Objects.equals(filter, "")) {
 			this.fontRendererObj.drawString(
 				StatCollector.translateToLocal(
 					"extracells.part.oredict.export.name").replace("ME ",
@@ -113,10 +111,10 @@ public class GuiOreDictExport extends GuiContainer {
 			this.fontRendererObj.drawString(
 				StatCollector.translateToLocal("container.inventory"), 8,
 				this.ySize - 94, 0x000000);
+		if (!filter.isEmpty() && !filter.startsWith("*")) {
 			this._containerOreDictExport.part.setFilter(filter, false);
 			Iterator<AEItemStack> items = this._containerOreDictExport.part.getOres().iterator();
 			int size = this._containerOreDictExport.part.getOres().size();
-
 			if (this.currentScroll < 0)
 				this.currentScroll = 0;
 			int maxPage = size / (4 * 10);
@@ -161,18 +159,18 @@ public class GuiOreDictExport extends GuiContainer {
 				this.guiLeft + this.xSize / 2 - 44, this.guiTop + 35, 88, 20,
 				StatCollector.translateToLocal("extracells.tooltip.save")));
 		this.searchbar = new GuiTextField(this.fontRendererObj, this.guiLeft
-				+ this.xSize / 2 - 75, this.guiTop + 20, 150, 10) {
+			+ this.xSize / 2 - 75, this.guiTop + 20, 150, 10) {
 
-			private int xPos = 0;
-			private int yPos = 0;
-			private int width = 0;
-			private int height = 0;
+			private final int xPos = 0;
+			private final int yPos = 0;
+			private final int width = 0;
+			private final int height = 0;
 
 
 			@Override
 			public void mouseClicked(int x, int y, int mouseBtn) {
 				boolean flag = x >= this.xPos && x < this.xPos + this.width
-						&& y >= this.yPos && y < this.yPos + this.height;
+					&& y >= this.yPos && y < this.yPos + this.height;
 				if (flag && mouseBtn == 3)
 					setText("");
 			}
@@ -181,6 +179,7 @@ public class GuiOreDictExport extends GuiContainer {
 		this.searchbar.setFocused(true);
 		this.searchbar.setMaxStringLength(128);
 		this.searchbar.setText(filter);
+
 	}
 
 	@Override

--- a/src/main/scala/extracells/integration/opencomputers/DriverFluidExportBus.java
+++ b/src/main/scala/extracells/integration/opencomputers/DriverFluidExportBus.java
@@ -3,6 +3,7 @@ package extracells.integration.opencomputers;
 import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartHost;
+import extracells.Extracells;
 import extracells.part.PartFluidExport;
 import extracells.part.PartGasExport;
 import extracells.registries.ItemEnum;
@@ -162,7 +163,7 @@ public class DriverFluidExportBus implements SidedBlock{
 				return new Object[]{false, "no export bus"};
 			if (part.getFacingTank() == null)
 				return new Object[]{false, "no tank"};
-			int amount = Math.min(args.optInteger(1, 625), 125 + part.getSpeedState() * 125);
+			int amount = Math.min(args.optInteger(1, Extracells.basePartSpeed() * 5), Extracells.basePartSpeed() + part.getSpeedState() * Extracells.basePartSpeed());
 			boolean didSomething = part.doWork(amount, 1) == TickRateModulation.FASTER;
 			if (didSomething)
 				context.pause(0.25);

--- a/src/main/scala/extracells/integration/opencomputers/DriverGasExportBus.java
+++ b/src/main/scala/extracells/integration/opencomputers/DriverGasExportBus.java
@@ -3,6 +3,7 @@ package extracells.integration.opencomputers;
 import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartHost;
+import extracells.Extracells;
 import extracells.part.PartGasExport;
 import extracells.registries.ItemEnum;
 import extracells.registries.PartEnum;
@@ -160,8 +161,8 @@ public class DriverGasExportBus implements SidedBlock{
                 return new Object[]{false, "no export bus"};
             if (part.getFacingGasTank() == null)
                 return new Object[]{false, "no tank"};
-            int amount = Math.min(args.optInteger(1, 625), 125 + part.getSpeedState() * 125);
-            boolean didSomething = part.doWork(amount, 1) == TickRateModulation.FASTER;
+			int amount = Math.min(args.optInteger(1, Extracells.basePartSpeed() * 5), Extracells.basePartSpeed() + part.getSpeedState() * Extracells.basePartSpeed());
+			boolean didSomething = part.doWork(amount, 1) == TickRateModulation.FASTER;
             if (didSomething)
                 context.pause(0.25);
             return new Object[]{didSomething};

--- a/src/main/scala/extracells/network/packet/part/PacketFluidStorage.java
+++ b/src/main/scala/extracells/network/packet/part/PacketFluidStorage.java
@@ -22,10 +22,20 @@ public class PacketFluidStorage extends AbstractPacket {
 
 	private IItemList<IAEFluidStack> fluidStackList;
 	private Fluid currentFluid;
+	Iterable<IAEFluidStack> change;
 	private boolean hasTermHandler;
 
 	@SuppressWarnings("unused")
-	public PacketFluidStorage() {}
+	public PacketFluidStorage() {
+	}
+
+	public PacketFluidStorage(EntityPlayer _player, Iterable<IAEFluidStack> _change, IItemList<IAEFluidStack> _list) {
+		super(_player);
+		this.mode = 4;
+		this.change = _change;
+		this.fluidStackList = _list;
+
+	}
 
 	public PacketFluidStorage(EntityPlayer _player) {
 		super(_player);
@@ -53,37 +63,54 @@ public class PacketFluidStorage extends AbstractPacket {
 	@Override
 	public void execute() {
 		switch (this.mode) {
-		case 0:
-			case0();
-			break;
-		case 1:
-			if (this.player != null && this.player.openContainer instanceof ContainerFluidStorage) {
-				((ContainerFluidStorage) this.player.openContainer).receiveSelectedFluid(this.currentFluid);
-			}else if (this.player != null && Integration.Mods.MEKANISMGAS.isEnabled() && this.player.openContainer instanceof ContainerGasStorage) {
-				((ContainerGasStorage) this.player.openContainer).receiveSelectedFluid(this.currentFluid);
-			}
-			break;
-		case 2:
-			if (this.player != null) {
-				if (!this.player.worldObj.isRemote) {
-					if (this.player.openContainer instanceof ContainerFluidStorage) {
-						((ContainerFluidStorage) this.player.openContainer).FluidUpdateOnce();
-						((ContainerFluidStorage) this.player.openContainer).doWork();
-					}else if (this.player.openContainer instanceof ContainerGasStorage && Integration.Mods.MEKANISMGAS.isEnabled()) {
-						((ContainerGasStorage) this.player.openContainer).forceFluidUpdate();
-						((ContainerGasStorage) this.player.openContainer).doWork();
+			case 0:
+				case0();
+				break;
+			case 1:
+				if (this.player != null && this.player.openContainer instanceof ContainerFluidStorage) {
+					((ContainerFluidStorage) this.player.openContainer).receiveSelectedFluid(this.currentFluid);
+				}else if (this.player != null && Integration.Mods.MEKANISMGAS.isEnabled() && this.player.openContainer instanceof ContainerGasStorage) {
+					((ContainerGasStorage) this.player.openContainer).receiveSelectedFluid(this.currentFluid);
+				}
+				break;
+			case 2:
+				if (this.player != null) {
+					if (!this.player.worldObj.isRemote) {
+						if (this.player.openContainer instanceof ContainerFluidStorage) {
+							((ContainerFluidStorage) this.player.openContainer).forceFluidUpdate();
+							((ContainerFluidStorage) this.player.openContainer).doWork();
+						} else if (this.player.openContainer instanceof ContainerGasStorage && Integration.Mods.MEKANISMGAS.isEnabled()) {
+							((ContainerGasStorage) this.player.openContainer).forceFluidUpdate();
+							((ContainerGasStorage) this.player.openContainer).doWork();
+						}
 					}
 				}
-			}
-			break;
-		case 3:
-			case3();
-			break;
+				break;
+			case 3:
+				case3();
+				break;
+			case 4:
+				case4();
+				break;
 		}
 	}
 
 	@SideOnly(Side.CLIENT)
-	private void case0(){
+	public void case4() {
+		if (this.player != null && this.player.isClientWorld()) {
+			Gui gui = Minecraft.getMinecraft().currentScreen;
+			if (gui instanceof GuiFluidStorage) {
+				ContainerFluidStorage container = (ContainerFluidStorage) ((GuiFluidStorage) gui).inventorySlots;
+				container.updateFluidList(this.fluidStackList, true);
+			} else if (gui instanceof GuiGasStorage) {
+				ContainerGasStorage container = (ContainerGasStorage) ((GuiGasStorage) gui).inventorySlots;
+				container.updateFluidList(this.fluidStackList, true);
+			}
+		}
+	}
+
+	@SideOnly(Side.CLIENT)
+	private void case0() {
 		if (this.player != null && this.player.isClientWorld()) {
 			Gui gui = Minecraft.getMinecraft().currentScreen;
 			if (gui instanceof GuiFluidStorage) {
@@ -113,7 +140,8 @@ public class PacketFluidStorage extends AbstractPacket {
 	@Override
 	public void readData(ByteBuf in) {
 		switch (this.mode) {
-		case 0:
+			case 0:
+			case 4:
 			this.fluidStackList = AEApi.instance().storage().createFluidList();
 			while (in.readableBytes() > 0) {
 				Fluid fluid = readFluid(in);
@@ -146,14 +174,20 @@ public class PacketFluidStorage extends AbstractPacket {
 				out.writeLong(fluidStack.amount);
 			}
 			break;
-		case 1:
-			writeFluid(this.currentFluid, out);
-			break;
-		case 2:
-			break;
-		case 3:
-			out.writeBoolean(this.hasTermHandler);
-			break;
+			case 1:
+				writeFluid(this.currentFluid, out);
+				break;
+			case 2:
+				break;
+			case 3:
+				out.writeBoolean(this.hasTermHandler);
+				break;
+			case 4:
+				for (IAEFluidStack stack : this.change) {
+					writeFluid(stack.getFluid(), out);
+					out.writeLong(stack.getStackSize());
+				}
+				break;
 		}
 	}
 }

--- a/src/main/scala/extracells/network/packet/part/PacketFluidTerminal.java
+++ b/src/main/scala/extracells/network/packet/part/PacketFluidTerminal.java
@@ -24,8 +24,19 @@ public class PacketFluidTerminal extends AbstractPacket {
 	Fluid currentFluid;
 	PartFluidTerminal terminalFluid;
 
+	Iterable<IAEFluidStack> change;
+
 	@SuppressWarnings("unused")
-	public PacketFluidTerminal() {}
+	public PacketFluidTerminal() {
+	}
+
+	public PacketFluidTerminal(EntityPlayer _player, Iterable<IAEFluidStack> _change, IItemList<IAEFluidStack> _list) {
+		super(_player);
+		this.mode = 4;
+		this.change = _change;
+		this.fluidStackList = _list;
+
+	}
 
 	public PacketFluidTerminal(EntityPlayer _player, Fluid _currentFluid) {
 		super(_player);
@@ -34,7 +45,7 @@ public class PacketFluidTerminal extends AbstractPacket {
 	}
 
 	public PacketFluidTerminal(EntityPlayer _player, Fluid _currentFluid,
-			PartFluidTerminal _terminalFluid) {
+							   PartFluidTerminal _terminalFluid) {
 		super(_player);
 		this.mode = 1;
 		this.currentFluid = _currentFluid;
@@ -58,31 +69,53 @@ public class PacketFluidTerminal extends AbstractPacket {
 	@Override
 	public void execute() {
 		switch (this.mode) {
-		case 0:
-			case0();
-			break;
-		case 1:
-			this.terminalFluid.setCurrentFluid(this.currentFluid);
-			break;
-		case 2:
-			case2();
-			break;
-		case 3:
-			if (this.player != null && this.player.openContainer instanceof ContainerFluidTerminal) {
-				ContainerFluidTerminal fluidContainer = (ContainerFluidTerminal) this.player.openContainer;
-				fluidContainer.forceFluidUpdate();
-				this.terminalFluid.sendCurrentFluid(fluidContainer);
-			} else if (this.player != null && this.player.openContainer instanceof ContainerGasTerminal) {
-				ContainerGasTerminal fluidContainer = (ContainerGasTerminal) this.player.openContainer;
-				fluidContainer.forceFluidUpdate();
-				this.terminalFluid.sendCurrentFluid(fluidContainer);
-			}
-			break;
+			case 0:
+				case0();
+				break;
+			case 1:
+				this.terminalFluid.setCurrentFluid(this.currentFluid);
+				break;
+			case 2:
+				case2();
+				break;
+			case 3:
+				case3();
+				break;
+			case 4:
+				case4();
+				break;
 		}
 	}
 
 	@SideOnly(Side.CLIENT)
-	public void case0(){
+	public void case4() {
+		if (this.player != null && this.player.isClientWorld()) {
+			Gui gui = Minecraft.getMinecraft().currentScreen;
+			if (gui instanceof GuiFluidTerminal) {
+				ContainerFluidTerminal container = (ContainerFluidTerminal) ((GuiFluidTerminal) gui).inventorySlots;
+				container.updateFluidList(this.fluidStackList, true);
+			} else if (gui instanceof GuiGasTerminal) {
+				ContainerGasTerminal container = (ContainerGasTerminal) ((GuiGasTerminal) gui).inventorySlots;
+				container.updateFluidList(this.fluidStackList, true);
+			}
+		}
+	}
+
+	@SideOnly(Side.CLIENT)
+	public void case3() {
+		if (this.player != null && this.player.openContainer instanceof ContainerFluidTerminal) {
+			ContainerFluidTerminal fluidContainer = (ContainerFluidTerminal) this.player.openContainer;
+			fluidContainer.forceFluidUpdate();
+			this.terminalFluid.sendCurrentFluid(fluidContainer);
+		} else if (this.player != null && this.player.openContainer instanceof ContainerGasTerminal) {
+			ContainerGasTerminal fluidContainer = (ContainerGasTerminal) this.player.openContainer;
+			fluidContainer.forceFluidUpdate();
+			this.terminalFluid.sendCurrentFluid(fluidContainer);
+		}
+	}
+
+	@SideOnly(Side.CLIENT)
+	public void case0() {
 		if (this.player != null && this.player.isClientWorld()) {
 			Gui gui = Minecraft.getMinecraft().currentScreen;
 			if (gui instanceof GuiFluidTerminal) {
@@ -109,7 +142,8 @@ public class PacketFluidTerminal extends AbstractPacket {
 	@Override
 	public void readData(ByteBuf in) {
 		switch (this.mode) {
-		case 0:
+			case 0:
+			case 4:
 			this.fluidStackList = AEApi.instance().storage().createFluidList();
 			while (in.readableBytes() > 0) {
 				Fluid fluid = readFluid(in);
@@ -145,16 +179,22 @@ public class PacketFluidTerminal extends AbstractPacket {
 				out.writeLong(stack.getStackSize());
 			}
 			break;
-		case 1:
-			writePart(this.terminalFluid, out);
-			writeFluid(this.currentFluid, out);
-			break;
-		case 2:
-			writeFluid(this.currentFluid, out);
-			break;
-		case 3:
-			writePart(this.terminalFluid, out);
-			break;
+			case 1:
+				writePart(this.terminalFluid, out);
+				writeFluid(this.currentFluid, out);
+				break;
+			case 2:
+				writeFluid(this.currentFluid, out);
+				break;
+			case 3:
+				writePart(this.terminalFluid, out);
+				break;
+			case 4:
+				for (IAEFluidStack stack : this.change) {
+					writeFluid(stack.getFluid(), out);
+					out.writeLong(stack.getStackSize());
+				}
+				break;
 		}
 	}
 }

--- a/src/main/scala/extracells/network/packet/part/PacketFluidTerminal.java
+++ b/src/main/scala/extracells/network/packet/part/PacketFluidTerminal.java
@@ -101,7 +101,6 @@ public class PacketFluidTerminal extends AbstractPacket {
 		}
 	}
 
-	@SideOnly(Side.CLIENT)
 	public void case3() {
 		if (this.player != null && this.player.openContainer instanceof ContainerFluidTerminal) {
 			ContainerFluidTerminal fluidContainer = (ContainerFluidTerminal) this.player.openContainer;

--- a/src/main/scala/extracells/network/packet/part/PacketFluidTerminal.java
+++ b/src/main/scala/extracells/network/packet/part/PacketFluidTerminal.java
@@ -143,29 +143,29 @@ public class PacketFluidTerminal extends AbstractPacket {
 		switch (this.mode) {
 			case 0:
 			case 4:
-			this.fluidStackList = AEApi.instance().storage().createFluidList();
-			while (in.readableBytes() > 0) {
-				Fluid fluid = readFluid(in);
-				long fluidAmount = in.readLong();
-				if (fluid == null || fluidAmount <= 0) {
-					continue;
-				}
-				IAEFluidStack stack = AEApi.instance().storage()
+				this.fluidStackList = AEApi.instance().storage().createFluidList();
+				while (in.readableBytes() > 0) {
+					Fluid fluid = readFluid(in);
+					long fluidAmount = in.readLong();
+					if (fluid == null) {
+						continue;
+					}
+					IAEFluidStack stack = AEApi.instance().storage()
 						.createFluidStack(new FluidStack(fluid, 1));
-				stack.setStackSize(fluidAmount);
-				this.fluidStackList.add(stack);
-			}
-			break;
-		case 1:
-			this.terminalFluid = (PartFluidTerminal) readPart(in);
-			this.currentFluid = readFluid(in);
-			break;
-		case 2:
-			this.currentFluid = readFluid(in);
-			break;
-		case 3:
-			this.terminalFluid = (PartFluidTerminal) readPart(in);
-			break;
+					stack.setStackSize(fluidAmount);
+					this.fluidStackList.add(stack);
+				}
+				break;
+			case 1:
+				this.terminalFluid = (PartFluidTerminal) readPart(in);
+				this.currentFluid = readFluid(in);
+				break;
+			case 2:
+				this.currentFluid = readFluid(in);
+				break;
+			case 3:
+				this.terminalFluid = (PartFluidTerminal) readPart(in);
+				break;
 		}
 	}
 

--- a/src/main/scala/extracells/part/PartFluidIO.java
+++ b/src/main/scala/extracells/part/PartFluidIO.java
@@ -9,9 +9,9 @@ import appeng.api.networking.ticking.TickingRequest;
 import appeng.api.parts.IPartCollisionHelper;
 import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPartRenderHelper;
-import appeng.api.parts.PartItemStack;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import extracells.Extracells;
 import extracells.container.ContainerBusFluidIO;
 import extracells.gui.GuiBusFluidIO;
 import extracells.item.ItemPartECBase;
@@ -44,8 +44,8 @@ public abstract class PartFluidIO extends PartECBase implements IGridTickable,
 	protected byte speedState;
 	protected boolean redstoneControlled;
 	private boolean lastRedstone;
-	private ECPrivateInventory upgradeInventory = new ECPrivateInventory("", 4,
-			1, this) {
+	private final ECPrivateInventory upgradeInventory = new ECPrivateInventory("", 4,
+		1, this) {
 
 		@Override
 		public boolean isItemValidForSlot(int i, ItemStack itemStack) {
@@ -55,9 +55,7 @@ public abstract class PartFluidIO extends PartECBase implements IGridTickable,
 				return true;
 			else if (AEApi.instance().definitions().materials().cardSpeed().isSameAs(itemStack))
 				return true;
-			else if (AEApi.instance().definitions().materials().cardRedstone().isSameAs(itemStack))
-				return true;
-			return false;
+			else return AEApi.instance().definitions().materials().cardRedstone().isSameAs(itemStack);
 		}
 	};
 
@@ -135,13 +133,13 @@ public abstract class PartFluidIO extends PartECBase implements IGridTickable,
 		if (tag.hasKey("speed"))
 			oldList.add(tag.getInteger("speed") + "mB/t");
 		else
-			oldList.add("125mB/t");
+			oldList.add(String.format("%smB/t", Extracells.basePartSpeed()));
 		return oldList;
 	}
 
 	@Override
 	public NBTTagCompound getWailaTag(NBTTagCompound tag) {
-		tag.setInteger("speed", 125 + this.speedState * 125);
+		tag.setInteger("speed", Extracells.basePartSpeed() + this.speedState * Extracells.basePartSpeed());
 		return tag;
 	}
 
@@ -253,7 +251,7 @@ public abstract class PartFluidIO extends PartECBase implements IGridTickable,
 	@Override
 	public final TickRateModulation tickingRequest(IGridNode node,
 			int TicksSinceLastCall) {
-		return canDoWork() ? doWork(125 + this.speedState * 125, TicksSinceLastCall)
+		return canDoWork() ? doWork(Extracells.basePartSpeed() + this.speedState * Extracells.basePartSpeed(), TicksSinceLastCall)
 			: TickRateModulation.IDLE;
 	}
 

--- a/src/main/scala/extracells/part/PartFluidImport.java
+++ b/src/main/scala/extracells/part/PartFluidImport.java
@@ -13,6 +13,7 @@ import appeng.api.util.AEColor;
 import cpw.mods.fml.common.FMLLog;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
+import extracells.Extracells;
 import extracells.render.TextureManager;
 import extracells.util.PermissionUtil;
 import net.minecraft.client.renderer.RenderBlocks;
@@ -101,7 +102,7 @@ public class PartFluidImport extends PartFluidIO implements IFluidHandler {
 		boolean redstonePowered = isRedstonePowered();
 		if (resource == null || redstonePowered && getRedstoneMode() == RedstoneMode.LOW_SIGNAL || !redstonePowered && getRedstoneMode() == RedstoneMode.HIGH_SIGNAL)
 			return 0;
-		int drainAmount = Math.min(125 + this.speedState * 125, resource.amount);
+		int drainAmount = Math.min(Extracells.basePartSpeed() + this.speedState * Extracells.basePartSpeed(), resource.amount);
 		FluidStack toFill = new FluidStack(resource.getFluid(), drainAmount);
 		Actionable action = doFill ? Actionable.MODULATE : Actionable.SIMULATE;
 		IAEFluidStack filled = injectFluid(AEApi.instance().storage().createFluidStack(toFill), action);

--- a/src/main/scala/extracells/part/PartFluidStorage.java
+++ b/src/main/scala/extracells/part/PartFluidStorage.java
@@ -20,7 +20,6 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import extracells.container.ContainerBusFluidStorage;
 import extracells.gui.GuiBusFluidStorage;
-import extracells.gui.GuiFluidStorage;
 import extracells.inventory.HandlerPartStorageFluid;
 import extracells.network.packet.other.IFluidSlotPartOrBlock;
 import extracells.network.packet.other.PacketFluidSlot;
@@ -29,7 +28,6 @@ import extracells.render.TextureManager;
 import extracells.util.PermissionUtil;
 import extracells.util.inventory.ECPrivateInventory;
 import extracells.util.inventory.IInventoryUpdateReceiver;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.EntityPlayer;
@@ -97,11 +95,7 @@ public class PartFluidStorage extends PartECBase implements ICellContainer, IInv
 
 	@Override
 	public Object getClientGuiElement(EntityPlayer player) {
-		if (Minecraft.getMinecraft().currentScreen instanceof GuiFluidStorage) {
-			return Minecraft.getMinecraft().currentScreen;
-		} else {
-			return new GuiBusFluidStorage(this, player);
-		}
+		return new GuiBusFluidStorage(this, player);
 	}
 
 	@Override

--- a/src/main/scala/extracells/part/PartFluidStorage.java
+++ b/src/main/scala/extracells/part/PartFluidStorage.java
@@ -20,6 +20,7 @@ import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import extracells.container.ContainerBusFluidStorage;
 import extracells.gui.GuiBusFluidStorage;
+import extracells.gui.GuiFluidStorage;
 import extracells.inventory.HandlerPartStorageFluid;
 import extracells.network.packet.other.IFluidSlotPartOrBlock;
 import extracells.network.packet.other.PacketFluidSlot;
@@ -28,6 +29,7 @@ import extracells.render.TextureManager;
 import extracells.util.PermissionUtil;
 import extracells.util.inventory.ECPrivateInventory;
 import extracells.util.inventory.IInventoryUpdateReceiver;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.EntityPlayer;
@@ -46,12 +48,12 @@ import java.util.List;
 
 public class PartFluidStorage extends PartECBase implements ICellContainer, IInventoryUpdateReceiver, IFluidSlotPartOrBlock, IPriorityHost {
 
-	private HashMap<IAEFluidStack, Long> fluidList = new HashMap<IAEFluidStack, Long>();
+	private final HashMap<IAEFluidStack, Long> fluidList = new HashMap<IAEFluidStack, Long>();
 	private int priority = 0;
 	protected HandlerPartStorageFluid handler = new HandlerPartStorageFluid(this);
-	private Fluid[] filterFluids = new Fluid[54];
+	private final Fluid[] filterFluids = new Fluid[54];
 	private AccessRestriction access = AccessRestriction.READ_WRITE;
-	private ECPrivateInventory upgradeInventory = new ECPrivateInventory("", 1, 1, this) {
+	private final ECPrivateInventory upgradeInventory = new ECPrivateInventory("", 1, 1, this) {
 
 		@Override
 		public boolean isItemValidForSlot(int i, ItemStack itemStack) {
@@ -95,7 +97,11 @@ public class PartFluidStorage extends PartECBase implements ICellContainer, IInv
 
 	@Override
 	public Object getClientGuiElement(EntityPlayer player) {
-		return new GuiBusFluidStorage(this, player);
+		if (Minecraft.getMinecraft().currentScreen instanceof GuiFluidStorage) {
+			return Minecraft.getMinecraft().currentScreen;
+		} else {
+			return new GuiBusFluidStorage(this, player);
+		}
 	}
 
 	@Override

--- a/src/main/scala/extracells/part/PartFluidTerminal.java
+++ b/src/main/scala/extracells/part/PartFluidTerminal.java
@@ -26,7 +26,6 @@ import extracells.util.FluidUtil;
 import extracells.util.PermissionUtil;
 import extracells.util.inventory.ECPrivateInventory;
 import extracells.util.inventory.IInventoryUpdateReceiver;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.item.EntityItem;
@@ -204,12 +203,9 @@ public class PartFluidTerminal extends PartECBase implements IGridTickable,
 
 	@Override
 	public Object getClientGuiElement(EntityPlayer player) {
-		if (Minecraft.getMinecraft().currentScreen instanceof GuiFluidTerminal) {
-			return Minecraft.getMinecraft().currentScreen;
-		} else {
-			return new GuiFluidTerminal(this, player);
-		}
+		return new GuiFluidTerminal(this, player);
 	}
+
 	public IInventory getInventory() {
 		return this.inventory;
 	}

--- a/src/main/scala/extracells/part/PartFluidTerminal.java
+++ b/src/main/scala/extracells/part/PartFluidTerminal.java
@@ -7,7 +7,10 @@ import appeng.api.networking.security.MachineSource;
 import appeng.api.networking.ticking.IGridTickable;
 import appeng.api.networking.ticking.TickRateModulation;
 import appeng.api.networking.ticking.TickingRequest;
-import appeng.api.parts.*;
+import appeng.api.parts.IPart;
+import appeng.api.parts.IPartCollisionHelper;
+import appeng.api.parts.IPartHost;
+import appeng.api.parts.IPartRenderHelper;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.util.AEColor;
@@ -23,6 +26,7 @@ import extracells.util.FluidUtil;
 import extracells.util.PermissionUtil;
 import extracells.util.inventory.ECPrivateInventory;
 import extracells.util.inventory.IInventoryUpdateReceiver;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.item.EntityItem;
@@ -45,9 +49,9 @@ public class PartFluidTerminal extends PartECBase implements IGridTickable,
 		IInventoryUpdateReceiver {
 
 	protected Fluid currentFluid;
-	private List<Object> containers = new ArrayList<Object>();
+	private final List<Object> containers = new ArrayList<Object>();
 	protected ECPrivateInventory inventory = new ECPrivateInventory(
-			"extracells.part.fluid.terminal", 2, 64, this) {
+		"extracells.part.fluid.terminal", 2, 64, this) {
 
 		@Override
 		public boolean isItemValidForSlot(int i, ItemStack itemStack) {
@@ -200,9 +204,12 @@ public class PartFluidTerminal extends PartECBase implements IGridTickable,
 
 	@Override
 	public Object getClientGuiElement(EntityPlayer player) {
-		return new GuiFluidTerminal(this, player);
+		if (Minecraft.getMinecraft().currentScreen instanceof GuiFluidTerminal) {
+			return Minecraft.getMinecraft().currentScreen;
+		} else {
+			return new GuiFluidTerminal(this, player);
+		}
 	}
-
 	public IInventory getInventory() {
 		return this.inventory;
 	}

--- a/src/main/scala/extracells/part/PartGasImport.scala
+++ b/src/main/scala/extracells/part/PartGasImport.scala
@@ -1,6 +1,5 @@
 package extracells.part
 
-import java.util
 import appeng.api.config.Actionable
 import appeng.api.networking.security.MachineSource
 import appeng.api.networking.ticking.TickRateModulation
@@ -8,6 +7,7 @@ import appeng.api.storage.IMEMonitor
 import appeng.api.storage.data.IAEFluidStack
 import cpw.mods.fml.common.Optional
 import cpw.mods.fml.common.Optional.{Interface, Method}
+import extracells.Extracells
 import extracells.integration.Integration
 import extracells.integration.mekanism.gas.MekanismGas
 import extracells.util.{FluidUtil, GasUtil}
@@ -15,15 +15,17 @@ import mekanism.api.gas.{Gas, GasStack, IGasHandler}
 import net.minecraftforge.common.util.ForgeDirection
 import net.minecraftforge.fluids.{Fluid, FluidStack}
 
+import java.util
+
 
 @Interface(iface = "mekanism.api.gas.IGasHandler", modid = "MekanismAPI|gas", striprefs = true)
-class PartGasImport extends PartFluidImport with IGasHandler{
+class PartGasImport extends PartFluidImport with IGasHandler {
 
-  private val isMekanismEnabled = Integration.Mods.MEKANISMGAS.isEnabled
+	private val isMekanismEnabled = Integration.Mods.MEKANISMGAS.isEnabled
 
-  override def doWork(rate: Int, TicksSinceLastCall: Int): TickRateModulation = {
-    if (!isActive || (!isMekanismEnabled) || getFacingGasTank == null) return TickRateModulation.IDLE
-    var empty: Boolean = true
+	override def doWork(rate: Int, TicksSinceLastCall: Int): TickRateModulation = {
+		if (!isActive || (!isMekanismEnabled) || getFacingGasTank == null) return TickRateModulation.IDLE
+		var empty: Boolean = true
     val filter: util.List[Fluid] = new util.ArrayList[Fluid]
     filter.add(this.filterFluids(4))
     if (this.filterSize >= 1) {
@@ -114,8 +116,8 @@ class PartGasImport extends PartFluidImport with IGasHandler{
   override def receiveGas(side: ForgeDirection, stack: GasStack, doTransfer: Boolean): Int = {
     if (stack == null || stack.amount <= 0 || ! canReceiveGas(side, stack.getGas))
       return 0
-    val amount = Math.min(stack.amount, 125 + this.speedState * 125)
-    val gasStack = GasUtil.createAEFluidStack(stack.getGas, amount)
+	  val amount = Math.min(stack.amount, Extracells.basePartSpeed + this.speedState * Extracells.basePartSpeed)
+	  val gasStack = GasUtil.createAEFluidStack(stack.getGas, amount)
     val notInjected = {
       if (getGridBlock == null) {
         gasStack

--- a/src/main/scala/extracells/part/PartOreDictExporter.java
+++ b/src/main/scala/extracells/part/PartOreDictExporter.java
@@ -24,6 +24,7 @@ import extracells.container.ContainerOreDictExport;
 import extracells.gui.GuiOreDictExport;
 import extracells.render.TextureManager;
 import extracells.util.ItemUtils;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.EntityPlayer;
@@ -38,8 +39,10 @@ import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.oredict.OreDictionary;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -336,7 +339,11 @@ public class PartOreDictExporter extends PartECBase implements IGridTickable {
 
 	@Override
 	public Object getClientGuiElement(EntityPlayer player) {
-		return new GuiOreDictExport(player, this);
+		if (Minecraft.getMinecraft().currentScreen instanceof GuiOreDictExport) {
+			return Minecraft.getMinecraft().currentScreen;
+		} else {
+			return new GuiOreDictExport(player, this);
+		}
 	}
 
 	@Override

--- a/src/main/scala/extracells/part/PartOreDictExporter.java
+++ b/src/main/scala/extracells/part/PartOreDictExporter.java
@@ -24,7 +24,6 @@ import extracells.container.ContainerOreDictExport;
 import extracells.gui.GuiOreDictExport;
 import extracells.render.TextureManager;
 import extracells.util.ItemUtils;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.RenderBlocks;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.entity.player.EntityPlayer;
@@ -339,11 +338,7 @@ public class PartOreDictExporter extends PartECBase implements IGridTickable {
 
 	@Override
 	public Object getClientGuiElement(EntityPlayer player) {
-		if (Minecraft.getMinecraft().currentScreen instanceof GuiOreDictExport) {
-			return Minecraft.getMinecraft().currentScreen;
-		} else {
-			return new GuiOreDictExport(player, this);
-		}
+		return new GuiOreDictExport(player, this);
 	}
 
 	@Override

--- a/src/main/scala/extracells/util/ExtraCellsEventHandler.java
+++ b/src/main/scala/extracells/util/ExtraCellsEventHandler.java
@@ -33,8 +33,10 @@ public class ExtraCellsEventHandler {
 				Container con = event.player.openContainer;
 				if (con instanceof ContainerFluidStorage) {
 					((ContainerFluidStorage) con).removeEnergyTick();
+					((ContainerFluidStorage) con).doWork();
 				}else if (con instanceof ContainerGasStorage) {
 					((ContainerGasStorage) con).removeEnergyTick();
+					((ContainerGasStorage) con).doWork();
 				}
 			}
 		}


### PR DESCRIPTION
Update the bandwidth occupation problem of opening the fluid terminal server(New solutions)
Optimize ore dict export bus export item preview (Items are not rendered when special characters begin)
Config flie add 
    Fluid update interval in fluid terminal  defalult interval:20 tick (Vanilla ec2  the fluid rendering speed is too fast)
    Base import export part speed default value:125 mb/t (The default rate is the same as before)
Selected fluid always updated on the every tick