### PR TITLE
EC2 Parts rendering consistent to AE2

### DIFF
--- a/src/main/scala/extracells/part/PartDrive.java
+++ b/src/main/scala/extracells/part/PartDrive.java
@@ -260,8 +260,9 @@ public class PartDrive extends PartECBase implements ICellContainer,
 			}
 		}
 
-		renderBackPanel(x, y, z, rh, renderer);
 		renderFrontPanel(x, y, z, rh, renderer);
+		renderBackPanel(x, y, z, rh, renderer);
+		renderPowerStatus(x, y, z, rh, renderer);
 	}
 
 	@Override

--- a/src/main/scala/extracells/part/PartDrive.java
+++ b/src/main/scala/extracells/part/PartDrive.java
@@ -220,18 +220,18 @@ public class PartDrive extends PartECBase implements ICellContainer,
 
 	@SideOnly(Side.CLIENT)
 	@Override
-	public void renderStatic(int x, int y, int z, IPartRenderHelper rh,
-			RenderBlocks renderer) {
-		Tessellator ts = Tessellator.instance;
+	public void renderStatic(int x, int y, int z, IPartRenderHelper rh, RenderBlocks renderer) {
+		// Render Front Screen
 		IIcon side = TextureManager.DRIVE_SIDE.getTexture();
 		IIcon[] front = TextureManager.DRIVE_FRONT.getTextures();
 		rh.setBounds(2, 2, 14, 14, 14, 15.999F);
 		rh.renderFace(x, y, z, front[3], ForgeDirection.SOUTH, renderer);
-		rh.setBounds(2, 2, 14, 14, 14, 16);
-		rh.setTexture(side, side, side, front[0], side, side);
-		rh.renderBlock(x, y, z, renderer);
 
-		ts.setColorOpaque_I(0xFFFFFF);
+		rh.setBounds(3, 3, 16, 13, 13, 16);
+		rh.setTexture(side, side, side, front[0], side, side);
+		rh.renderFace(x, y, z, front[0], ForgeDirection.SOUTH, renderer);
+
+		Tessellator.instance.setColorOpaque_I(0xFFFFFF);
 		for (int i = 0; i < 2; i++) {
 			for (int j = 0; j < 3; j++) {
 				if (this.cellStatuses[j + i * 3] > 0) {
@@ -254,14 +254,14 @@ public class PartDrive extends PartECBase implements ICellContainer,
 					rh.setBounds(8, 12 - j * 3, 14, 13, 10 - j * 3, 16);
 				else
 					rh.setBounds(3, 12 - j * 3, 14, 8, 10 - j * 3, 16);
-				ts.setColorOpaque_I(getColorByStatus(this.cellStatuses[j + i
-						* 3]));
-				ts.setBrightness(13 << 20 | 13 << 4);
+				Tessellator.instance.setColorOpaque_I(getColorByStatus(this.cellStatuses[j + i * 3]));
+				Tessellator.instance.setBrightness(13 << 20 | 13 << 4);
 				rh.renderFace(x, y, z, front[2], ForgeDirection.SOUTH, renderer);
 			}
 		}
-		rh.setBounds(5, 5, 13, 11, 11, 14);
-		renderStaticBusLights(x, y, z, rh, renderer);
+
+		renderBackPanel(x, y, z, rh, renderer);
+		renderFrontPanel(x, y, z, rh, renderer);
 	}
 
 	@Override

--- a/src/main/scala/extracells/part/PartECBase.java
+++ b/src/main/scala/extracells/part/PartECBase.java
@@ -17,6 +17,8 @@ import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.util.AECableType;
 import appeng.api.util.AEColor;
 import appeng.api.util.DimensionalCoord;
+import appeng.client.texture.CableBusTextures;
+import appeng.items.parts.ItemMultiPart;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Optional;
 import cpw.mods.fml.relauncher.Side;
@@ -403,6 +405,48 @@ public abstract class PartECBase implements IPart, IGridHost, IActionHost,
 		rh.renderInventoryFace(TextureManager.BUS_COLOR.getTextures()[1], ForgeDirection.EAST, renderer);
 		rh.renderInventoryFace(TextureManager.BUS_COLOR.getTextures()[1], ForgeDirection.SOUTH, renderer);
 		rh.renderInventoryFace(TextureManager.BUS_COLOR.getTextures()[1], ForgeDirection.WEST, renderer);
+	}
+
+	protected void renderBackPanel(int x, int y, int z, IPartRenderHelper rh, RenderBlocks renderer) {
+		// Render back panel
+		final IIcon backTexture = CableBusTextures.PartMonitorBack.getIcon();
+		final IIcon sideStatusTexture = CableBusTextures.PartMonitorSidesStatus.getIcon();
+		final IIcon noTexture = ItemMultiPart.instance.getIconFromDamage(380);
+
+		rh.setTexture(sideStatusTexture, sideStatusTexture, backTexture, noTexture, sideStatusTexture, sideStatusTexture);
+		rh.setBounds(4, 4, 13, 12, 12, 14);
+		rh.renderBlock(x, y, z, renderer);
+
+		// Render power status
+		if (isActive()) {
+			final int l = 14;
+			Tessellator.instance.setBrightness(l << 20 | l << 4);
+			Tessellator.instance.setColorOpaque_I(host.getColor().blackVariant);
+		} else if (isPowered()) {
+			final int l = 9;
+			Tessellator.instance.setBrightness(l << 20 | l << 4);
+			Tessellator.instance.setColorOpaque_I(host.getColor().whiteVariant);
+		} else {
+			Tessellator.instance.setBrightness(0);
+			Tessellator.instance.setColorOpaque_I(0x000000);
+		}
+
+		final IIcon sideStatusLightTexture = CableBusTextures.PartMonitorSidesStatusLights.getIcon();
+
+		rh.renderFace(x, y, z, sideStatusLightTexture, ForgeDirection.EAST, renderer);
+		rh.renderFace(x, y, z, sideStatusLightTexture, ForgeDirection.WEST, renderer);
+		rh.renderFace(x, y, z, sideStatusLightTexture, ForgeDirection.UP, renderer);
+		rh.renderFace(x, y, z, sideStatusLightTexture, ForgeDirection.DOWN, renderer);
+	}
+
+	protected void renderFrontPanel(int x, int y, int z, IPartRenderHelper rh, RenderBlocks renderer) {
+		final IIcon sideTexture = CableBusTextures.PartMonitorSides.getIcon();
+		final IIcon backTexture = CableBusTextures.PartMonitorBack.getIcon();
+		final IIcon noTexture = ItemMultiPart.instance.getIconFromDamage(380);
+
+		rh.setTexture(sideTexture, sideTexture, backTexture, noTexture, sideTexture, sideTexture);
+		rh.setBounds(2, 2, 14, 14, 14, 16);
+		rh.renderBlock(x, y, z, renderer);
 	}
 
 	@Override

--- a/src/main/scala/extracells/part/PartECBase.java
+++ b/src/main/scala/extracells/part/PartECBase.java
@@ -408,7 +408,6 @@ public abstract class PartECBase implements IPart, IGridHost, IActionHost,
 	}
 
 	protected void renderBackPanel(int x, int y, int z, IPartRenderHelper rh, RenderBlocks renderer) {
-		// Render back panel
 		final IIcon backTexture = CableBusTextures.PartMonitorBack.getIcon();
 		final IIcon sideStatusTexture = CableBusTextures.PartMonitorSidesStatus.getIcon();
 		final IIcon noTexture = ItemMultiPart.instance.getIconFromDamage(380);
@@ -416,8 +415,9 @@ public abstract class PartECBase implements IPart, IGridHost, IActionHost,
 		rh.setTexture(sideStatusTexture, sideStatusTexture, backTexture, noTexture, sideStatusTexture, sideStatusTexture);
 		rh.setBounds(4, 4, 13, 12, 12, 14);
 		rh.renderBlock(x, y, z, renderer);
+	}
 
-		// Render power status
+	protected void renderPowerStatus(int x, int y, int z, IPartRenderHelper rh, RenderBlocks renderer) {
 		if (isActive()) {
 			final int l = 14;
 			Tessellator.instance.setBrightness(l << 20 | l << 4);
@@ -432,7 +432,6 @@ public abstract class PartECBase implements IPart, IGridHost, IActionHost,
 		}
 
 		final IIcon sideStatusLightTexture = CableBusTextures.PartMonitorSidesStatusLights.getIcon();
-
 		rh.renderFace(x, y, z, sideStatusLightTexture, ForgeDirection.EAST, renderer);
 		rh.renderFace(x, y, z, sideStatusLightTexture, ForgeDirection.WEST, renderer);
 		rh.renderFace(x, y, z, sideStatusLightTexture, ForgeDirection.UP, renderer);

--- a/src/main/scala/extracells/part/PartFluidConversionMonitor.java
+++ b/src/main/scala/extracells/part/PartFluidConversionMonitor.java
@@ -124,8 +124,9 @@ public class PartFluidConversionMonitor extends PartFluidStorageMonitor {
 		Tessellator.instance.setColorOpaque_I(host.getColor().blackVariant);
 		rh.renderFace(x, y, z, TextureManager.CONVERSION_MONITOR.getTextures()[2], ForgeDirection.SOUTH, renderer);
 
-		renderBackPanel(x, y, z, rh, renderer);
 		renderFrontPanel(x, y, z, rh, renderer);
+		renderBackPanel(x, y, z, rh, renderer);
+		renderPowerStatus(x, y, z, rh, renderer);
 	}
 
 }

--- a/src/main/scala/extracells/part/PartFluidConversionMonitor.java
+++ b/src/main/scala/extracells/part/PartFluidConversionMonitor.java
@@ -112,43 +112,20 @@ public class PartFluidConversionMonitor extends PartFluidStorageMonitor {
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderStatic(int x, int y, int z, IPartRenderHelper rh,
-			RenderBlocks renderer) {
-		Tessellator ts = Tessellator.instance;
+	public void renderStatic(int x, int y, int z, IPartRenderHelper rh, RenderBlocks renderer) {
+		final IPartHost host = getHost();
 
-		IIcon side = TextureManager.TERMINAL_SIDE.getTexture();
-		rh.setTexture(side);
-		rh.setBounds(4, 4, 13, 12, 12, 14);
-		rh.renderBlock(x, y, z, renderer);
-		rh.setTexture(side, side, side, TextureManager.BUS_BORDER.getTexture(),
-				side, side);
-		rh.setBounds(2, 2, 14, 14, 14, 16);
-		rh.renderBlock(x, y, z, renderer);
-
-		if (isActive())
-			Tessellator.instance.setBrightness(13 << 20 | 13 << 4);
-
-		ts.setColorOpaque_I(0xFFFFFF);
-		rh.renderFace(x, y, z, TextureManager.BUS_BORDER.getTexture(),
-				ForgeDirection.SOUTH, renderer);
-
-		IPartHost host = getHost();
+		// Render Front Screen
 		rh.setBounds(3, 3, 15, 13, 13, 16);
-		ts.setColorOpaque_I(host.getColor().mediumVariant);
-		rh.renderFace(x, y, z,
-				TextureManager.CONVERSION_MONITOR.getTextures()[0],
-				ForgeDirection.SOUTH, renderer);
-		ts.setColorOpaque_I(host.getColor().whiteVariant);
-		rh.renderFace(x, y, z,
-				TextureManager.CONVERSION_MONITOR.getTextures()[1],
-				ForgeDirection.SOUTH, renderer);
-		ts.setColorOpaque_I(host.getColor().blackVariant);
-		rh.renderFace(x, y, z,
-				TextureManager.CONVERSION_MONITOR.getTextures()[2],
-				ForgeDirection.SOUTH, renderer);
+		Tessellator.instance.setColorOpaque_I(host.getColor().mediumVariant);
+		rh.renderFace(x, y, z, TextureManager.CONVERSION_MONITOR.getTextures()[0], ForgeDirection.SOUTH, renderer);
+		Tessellator.instance.setColorOpaque_I(host.getColor().whiteVariant);
+		rh.renderFace(x, y, z, TextureManager.CONVERSION_MONITOR.getTextures()[1], ForgeDirection.SOUTH, renderer);
+		Tessellator.instance.setColorOpaque_I(host.getColor().blackVariant);
+		rh.renderFace(x, y, z, TextureManager.CONVERSION_MONITOR.getTextures()[2], ForgeDirection.SOUTH, renderer);
 
-		rh.setBounds(5, 5, 12, 11, 11, 13);
-		renderStaticBusLights(x, y, z, rh, renderer);
+		renderBackPanel(x, y, z, rh, renderer);
+		renderFrontPanel(x, y, z, rh, renderer);
 	}
 
 }

--- a/src/main/scala/extracells/part/PartFluidStorage.java
+++ b/src/main/scala/extracells/part/PartFluidStorage.java
@@ -193,24 +193,26 @@ public class PartFluidStorage extends PartECBase implements ICellContainer, IInv
 	@SideOnly(Side.CLIENT)
 	@Override
 	public void renderInventory(IPartRenderHelper rh, RenderBlocks renderer) {
-		Tessellator ts = Tessellator.instance;
+		final IIcon sideTexture = CableBusTextures.PartStorageSides.getIcon();
+		final IIcon backTexture = CableBusTextures.PartStorageBack.getIcon();
+		final IIcon frontTexture = TextureManager.STORAGE_FRONT.getTexture();
+		final IIcon noTexture = ItemMultiPart.instance.getIconFromDamage(220);
 
-		IIcon side = TextureManager.STORAGE_SIDE.getTexture();
-		rh.setTexture(side, side, side,
-				TextureManager.STORAGE_FRONT.getTextures()[0], side, side);
-		rh.setBounds(2, 2, 15, 14, 14, 16);
+		rh.setTexture(sideTexture, sideTexture, noTexture, frontTexture, sideTexture, sideTexture);
+		rh.setBounds(3, 3, 15, 13, 13, 16);
 		rh.renderInventoryBox(renderer);
 
-		rh.setBounds(4, 4, 14, 12, 12, 15);
+		rh.setTexture(sideTexture, sideTexture, backTexture, noTexture, sideTexture, sideTexture);
+		rh.setBounds(2, 2, 14, 14, 14, 15);
 		rh.renderInventoryBox(renderer);
+
+		rh.setBounds(5, 5, 12, 11, 11, 14);
+		rh.renderInventoryBox(renderer);
+
 		rh.setBounds(2, 2, 15, 14, 14, 16);
 		rh.setInvColor(AEColor.Cyan.blackVariant);
-		ts.setBrightness(15 << 20 | 15 << 4);
-		rh.renderInventoryFace(TextureManager.STORAGE_FRONT.getTextures()[1],
-				ForgeDirection.SOUTH, renderer);
-
-		rh.setBounds(5, 5, 13, 11, 11, 14);
-		renderInventoryBusLights(rh, renderer);
+		Tessellator.instance.setBrightness(15 << 20 | 15 << 4);
+		rh.renderInventoryFace(TextureManager.STORAGE_FRONT.getTextures()[1], ForgeDirection.SOUTH, renderer);
 	}
 
 	@SideOnly(Side.CLIENT)

--- a/src/main/scala/extracells/part/PartFluidStorage.java
+++ b/src/main/scala/extracells/part/PartFluidStorage.java
@@ -8,6 +8,7 @@ import appeng.api.networking.IGridNode;
 import appeng.api.networking.events.*;
 import appeng.api.parts.IPart;
 import appeng.api.parts.IPartCollisionHelper;
+import appeng.api.parts.IPartHost;
 import appeng.api.parts.IPartRenderHelper;
 import appeng.api.storage.ICellContainer;
 import appeng.api.storage.IMEInventory;
@@ -15,7 +16,9 @@ import appeng.api.storage.IMEInventoryHandler;
 import appeng.api.storage.StorageChannel;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.util.AEColor;
+import appeng.client.texture.CableBusTextures;
 import appeng.helpers.IPriorityHost;
+import appeng.items.parts.ItemMultiPart;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import extracells.container.ContainerBusFluidStorage;
@@ -212,26 +215,33 @@ public class PartFluidStorage extends PartECBase implements ICellContainer, IInv
 
 	@SideOnly(Side.CLIENT)
 	@Override
-	public void renderStatic(int x, int y, int z, IPartRenderHelper rh,
-			RenderBlocks renderer) {
-		Tessellator ts = Tessellator.instance;
+	public void renderStatic(int x, int y, int z, IPartRenderHelper rh, RenderBlocks renderer) {
+		final IPartHost host = getHost();
+		final IIcon sideTexture = CableBusTextures.PartStorageSides.getIcon();
+		final IIcon backTexture = CableBusTextures.PartStorageBack.getIcon();
+		final IIcon frontTexture = TextureManager.STORAGE_FRONT.getTexture();
+		final IIcon noTexture = ItemMultiPart.instance.getIconFromDamage(220);
 
-		IIcon side = TextureManager.STORAGE_SIDE.getTexture();
-		rh.setTexture(side, side, side,
-				TextureManager.STORAGE_FRONT.getTexture(), side, side);
-		rh.setBounds(2, 2, 15, 14, 14, 16);
+		rh.setTexture(sideTexture, sideTexture, noTexture, frontTexture, sideTexture, sideTexture);
+		rh.setBounds(3, 3, 15, 13, 13, 16);
 		rh.renderBlock(x, y, z, renderer);
 
-		ts.setColorOpaque_I(getHost().getColor().blackVariant);
+		Tessellator.instance.setColorOpaque_I(host.getColor().blackVariant);
 		if (isActive())
-			ts.setBrightness(15 << 20 | 15 << 4);
-		rh.renderFace(x, y, z, TextureManager.STORAGE_FRONT.getTextures()[1],
-				ForgeDirection.SOUTH, renderer);
-		rh.setBounds(4, 4, 14, 12, 12, 15);
+			Tessellator.instance.setBrightness(14 << 20 | 14 << 4);
+		rh.renderFace(x, y, z, TextureManager.STORAGE_FRONT.getTextures()[1], ForgeDirection.SOUTH, renderer);
+
+		rh.setTexture(sideTexture, sideTexture, backTexture, noTexture, sideTexture, sideTexture);
+		rh.setBounds(2, 2, 14, 14, 14, 15);
+		rh.renderBlock(x, y, z, renderer);
+
+		rh.setBounds(5, 5, 12, 11, 11, 13);
 		rh.renderBlock(x, y, z, renderer);
 
 		rh.setBounds(5, 5, 13, 11, 11, 14);
-		renderStaticBusLights(x, y, z, rh, renderer);
+		rh.renderBlock(x, y, z, renderer);
+
+		renderPowerStatus(x, y, z, rh, renderer);
 	}
 
 	@Override

--- a/src/main/scala/extracells/part/PartFluidStorageMonitor.java
+++ b/src/main/scala/extracells/part/PartFluidStorageMonitor.java
@@ -451,40 +451,20 @@ public class PartFluidStorageMonitor extends PartECBase implements IStackWatcher
 
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void renderStatic(int x, int y, int z, IPartRenderHelper rh,
-			RenderBlocks renderer) {
-		Tessellator ts = Tessellator.instance;
+	public void renderStatic(int x, int y, int z, IPartRenderHelper rh, RenderBlocks renderer) {
+		final IPartHost host = getHost();
 
-		IIcon side = TextureManager.TERMINAL_SIDE.getTexture();
-		rh.setTexture(side);
-		rh.setBounds(4, 4, 13, 12, 12, 14);
-		rh.renderBlock(x, y, z, renderer);
-		rh.setTexture(side, side, side, TextureManager.BUS_BORDER.getTexture(),
-				side, side);
-		rh.setBounds(2, 2, 14, 14, 14, 16);
-		rh.renderBlock(x, y, z, renderer);
-
-		if (isActive())
-			Tessellator.instance.setBrightness(13 << 20 | 13 << 4);
-
-		ts.setColorOpaque_I(0xFFFFFF);
-		rh.renderFace(x, y, z, TextureManager.BUS_BORDER.getTexture(),
-				ForgeDirection.SOUTH, renderer);
-
-		IPartHost host = getHost();
+		// Render Front Screen
 		rh.setBounds(3, 3, 15, 13, 13, 16);
-		ts.setColorOpaque_I(host.getColor().mediumVariant);
-		rh.renderFace(x, y, z, TextureManager.STORAGE_MONITOR.getTextures()[0],
-				ForgeDirection.SOUTH, renderer);
-		ts.setColorOpaque_I(host.getColor().whiteVariant);
-		rh.renderFace(x, y, z, TextureManager.STORAGE_MONITOR.getTextures()[1],
-				ForgeDirection.SOUTH, renderer);
-		ts.setColorOpaque_I(host.getColor().blackVariant);
-		rh.renderFace(x, y, z, TextureManager.STORAGE_MONITOR.getTextures()[2],
-				ForgeDirection.SOUTH, renderer);
+		Tessellator.instance.setColorOpaque_I(host.getColor().mediumVariant);
+		rh.renderFace(x, y, z, TextureManager.STORAGE_MONITOR.getTextures()[0], ForgeDirection.SOUTH, renderer);
+		Tessellator.instance.setColorOpaque_I(host.getColor().whiteVariant);
+		rh.renderFace(x, y, z, TextureManager.STORAGE_MONITOR.getTextures()[1], ForgeDirection.SOUTH, renderer);
+		Tessellator.instance.setColorOpaque_I(host.getColor().blackVariant);
+		rh.renderFace(x, y, z, TextureManager.STORAGE_MONITOR.getTextures()[2], ForgeDirection.SOUTH, renderer);
 
-		rh.setBounds(5, 5, 12, 11, 11, 13);
-		renderStaticBusLights(x, y, z, rh, renderer);
+		renderBackPanel(x, y, z, rh, renderer);
+		renderFrontPanel(x, y, z, rh, renderer);
 	}
 
 	@Override

--- a/src/main/scala/extracells/part/PartFluidStorageMonitor.java
+++ b/src/main/scala/extracells/part/PartFluidStorageMonitor.java
@@ -463,8 +463,9 @@ public class PartFluidStorageMonitor extends PartECBase implements IStackWatcher
 		Tessellator.instance.setColorOpaque_I(host.getColor().blackVariant);
 		rh.renderFace(x, y, z, TextureManager.STORAGE_MONITOR.getTextures()[2], ForgeDirection.SOUTH, renderer);
 
-		renderBackPanel(x, y, z, rh, renderer);
 		renderFrontPanel(x, y, z, rh, renderer);
+		renderBackPanel(x, y, z, rh, renderer);
+		renderPowerStatus(x, y, z, rh, renderer);
 	}
 
 	@Override

--- a/src/main/scala/extracells/part/PartFluidTerminal.java
+++ b/src/main/scala/extracells/part/PartFluidTerminal.java
@@ -289,33 +289,19 @@ public class PartFluidTerminal extends PartECBase implements IGridTickable,
 	@SideOnly(Side.CLIENT)
 	@Override
 	public void renderStatic(int x, int y, int z, IPartRenderHelper rh, RenderBlocks renderer) {
-		Tessellator ts = Tessellator.instance;
+		final IPartHost host = getHost();
 
-		IIcon side = TextureManager.TERMINAL_SIDE.getTexture();
-		rh.setTexture(side);
-		rh.setBounds(4, 4, 13, 12, 12, 14);
-		rh.renderBlock(x, y, z, renderer);
-		rh.setTexture(side, side, side, TextureManager.BUS_BORDER.getTexture(), side, side);
-		rh.setBounds(2, 2, 14, 14, 14, 16);
-		rh.renderBlock(x, y, z, renderer);
-
-		if (isActive())
-			Tessellator.instance.setBrightness(13 << 20 | 13 << 4);
-
-		ts.setColorOpaque_I(0xFFFFFF);
-		rh.renderFace(x, y, z, TextureManager.BUS_BORDER.getTexture(), ForgeDirection.SOUTH, renderer);
-
-		IPartHost host = getHost();
+		// Render front screen
 		rh.setBounds(3, 3, 15, 13, 13, 16);
-		ts.setColorOpaque_I(host.getColor().blackVariant);
+		Tessellator.instance.setColorOpaque_I(host.getColor().blackVariant);
 		rh.renderFace(x, y, z, TextureManager.TERMINAL_FRONT.getTextures()[0], ForgeDirection.SOUTH, renderer);
-		ts.setColorOpaque_I(host.getColor().mediumVariant);
+		Tessellator.instance.setColorOpaque_I(host.getColor().mediumVariant);
 		rh.renderFace(x, y, z, TextureManager.TERMINAL_FRONT.getTextures()[1], ForgeDirection.SOUTH, renderer);
-		ts.setColorOpaque_I(host.getColor().whiteVariant);
+		Tessellator.instance.setColorOpaque_I(host.getColor().whiteVariant);
 		rh.renderFace(x, y, z, TextureManager.TERMINAL_FRONT.getTextures()[2], ForgeDirection.SOUTH, renderer);
 
-		rh.setBounds(5, 5, 12, 11, 11, 13);
-		renderStaticBusLights(x, y, z, rh, renderer);
+		renderBackPanel(x, y, z, rh, renderer);
+		renderFrontPanel(x, y, z, rh, renderer);
 	}
 
 	public void sendCurrentFluid() {

--- a/src/main/scala/extracells/part/PartFluidTerminal.java
+++ b/src/main/scala/extracells/part/PartFluidTerminal.java
@@ -14,6 +14,8 @@ import appeng.api.parts.IPartRenderHelper;
 import appeng.api.storage.IMEMonitor;
 import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.util.AEColor;
+import appeng.client.texture.CableBusTextures;
+import appeng.items.parts.ItemMultiPart;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import extracells.container.ContainerFluidTerminal;
@@ -254,36 +256,27 @@ public class PartFluidTerminal extends PartECBase implements IGridTickable,
 	@SideOnly(Side.CLIENT)
 	@Override
 	public void renderInventory(IPartRenderHelper rh, RenderBlocks renderer) {
-		Tessellator ts = Tessellator.instance;
+		final IIcon sideTexture = CableBusTextures.PartMonitorSides.getIcon();
+		final IIcon backTexture = CableBusTextures.PartMonitorBack.getIcon();
 
-		IIcon side = TextureManager.TERMINAL_SIDE.getTexture();
-		rh.setTexture(side);
+		// Back Panel
+		rh.setTexture(sideTexture, sideTexture, backTexture, sideTexture, sideTexture, sideTexture);
 		rh.setBounds(4, 4, 13, 12, 12, 14);
 		rh.renderInventoryBox(renderer);
-		rh.setTexture(side, side, side, TextureManager.BUS_BORDER.getTexture(),
-				side, side);
+
+		// Front Panel
+		rh.setTexture(sideTexture, sideTexture, backTexture, TextureManager.BUS_BORDER.getTexture(), sideTexture, sideTexture);
 		rh.setBounds(2, 2, 14, 14, 14, 16);
 		rh.renderInventoryBox(renderer);
 
-		ts.setBrightness(13 << 20 | 13 << 4);
-
-		rh.setInvColor(0xFFFFFF);
-		rh.renderInventoryFace(TextureManager.BUS_BORDER.getTexture(),
-				ForgeDirection.SOUTH, renderer);
-
+		// Front Screen
 		rh.setBounds(3, 3, 15, 13, 13, 16);
 		rh.setInvColor(AEColor.Transparent.blackVariant);
-		rh.renderInventoryFace(TextureManager.TERMINAL_FRONT.getTextures()[0],
-				ForgeDirection.SOUTH, renderer);
+		rh.renderInventoryFace(TextureManager.TERMINAL_FRONT.getTextures()[0], ForgeDirection.SOUTH, renderer);
 		rh.setInvColor(AEColor.Transparent.mediumVariant);
-		rh.renderInventoryFace(TextureManager.TERMINAL_FRONT.getTextures()[1],
-				ForgeDirection.SOUTH, renderer);
+		rh.renderInventoryFace(TextureManager.TERMINAL_FRONT.getTextures()[1], ForgeDirection.SOUTH, renderer);
 		rh.setInvColor(AEColor.Transparent.whiteVariant);
-		rh.renderInventoryFace(TextureManager.TERMINAL_FRONT.getTextures()[2],
-				ForgeDirection.SOUTH, renderer);
-
-		rh.setBounds(5, 5, 12, 11, 11, 13);
-		renderInventoryBusLights(rh, renderer);
+		rh.renderInventoryFace(TextureManager.TERMINAL_FRONT.getTextures()[2], ForgeDirection.SOUTH, renderer);
 	}
 
 	@SideOnly(Side.CLIENT)

--- a/src/main/scala/extracells/part/PartFluidTerminal.java
+++ b/src/main/scala/extracells/part/PartFluidTerminal.java
@@ -300,8 +300,9 @@ public class PartFluidTerminal extends PartECBase implements IGridTickable,
 		Tessellator.instance.setColorOpaque_I(host.getColor().whiteVariant);
 		rh.renderFace(x, y, z, TextureManager.TERMINAL_FRONT.getTextures()[2], ForgeDirection.SOUTH, renderer);
 
-		renderBackPanel(x, y, z, rh, renderer);
 		renderFrontPanel(x, y, z, rh, renderer);
+		renderBackPanel(x, y, z, rh, renderer);
+		renderPowerStatus(x, y, z, rh, renderer);
 	}
 
 	public void sendCurrentFluid() {


### PR DESCRIPTION
This PR changes few EC2 parts rendering, to be consistent with AE2.

Example:
Fluid Storage Bus (before):
![image](https://user-images.githubusercontent.com/22837945/194967616-0a72b5d6-db00-44e9-87d0-0844bb61e500.png)

Fluid Storage Bus (after):
![image](https://user-images.githubusercontent.com/22837945/194967569-33bbaedb-65be-42c2-b4ef-6843889f57ad.png)

Fluid Terminal (before):
![image](https://user-images.githubusercontent.com/22837945/194967769-eeba489d-2a6a-4b2f-8dd1-6b53c4b98210.png)

Fluid Terminal (after):
![image](https://user-images.githubusercontent.com/22837945/194967812-4ef34ad0-4269-4f18-b48c-afc4c491d6e2.png)

AE2 Storage Bus (for comparison):
![image](https://user-images.githubusercontent.com/22837945/194967896-7ac6160b-8d01-4142-8934-1c511ec04031.png)


I've also changed something else, but not everything, since most of the stuff are already being replaced by AE2FC version. Probably the only parts from EC2 being still used are the terminal and storage bus.
